### PR TITLE
Make Falcon::Adapters::Input#read behave like IO#read

### DIFF
--- a/lib/falcon/adapters/input.rb
+++ b/lib/falcon/adapters/input.rb
@@ -49,22 +49,23 @@ module Falcon
 			end
 			
 			def read(length = nil, buffer = nil)
+				buffer ||= Async::IO::BinaryString.new
+				buffer.clear
+				
 				if length
 					fill_buffer(length) if @buffer.bytesize <= length
 					
-					return @buffer.slice!(0, length)
+					buffer << @buffer.slice!(0, length)
 				else
-					buffer ||= Async::IO::BinaryString.new
-					
 					buffer << @buffer
 					@buffer.clear
 					
 					while chunk = read_next
 						buffer << chunk
 					end
-					
-					return buffer
 				end
+				
+				buffer unless length && length > 0 && buffer.empty?
 			end
 			
 			def eof?

--- a/spec/falcon/adapters/input_spec.rb
+++ b/spec/falcon/adapters/input_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Falcon::Adapters::Input do
 		context '#read' do
 			it "can read all input" do
 				expect(subject.read).to be == sample_data.join
+				expect(subject.read).to be == ""
 			end
 			
 			it "can read partial input" do
@@ -45,8 +46,36 @@ RSpec.describe Falcon::Adapters::Input do
 				expect(subject.read(15)).to be == sample_data.join[0...15]
 				expect(subject.read).to be == sample_data.join[15..-1]
 				
+				expect(subject.read(1)).to be == nil
 				expect(subject).to be_eof
 			end
+			
+			it "can read partial input with buffer" do
+				buffer = String.new
+				
+				2.times do
+					expect(subject.read(3, buffer)).to be == "The"
+					expect(subject.read(3, buffer)).to be == "qui"
+					expect(subject.read(3, buffer)).to be == "ckb"
+					expect(subject.read(3, buffer)).to be == "row"
+					
+					expect(buffer).to be == "row"
+					
+					subject.rewind
+				end
+				
+				data = subject.read(15, buffer)
+				expect(data).to be == sample_data.join[0...15]
+				expect(buffer).to equal(data)
+				
+				expect(subject.read).to be == sample_data.join[15..-1]
+				
+				expect(subject.read(1, buffer)).to be == nil
+				expect(buffer).to be == ""
+				
+				expect(subject).to be_eof
+			end
+		
 		end
 		
 		context '#each' do
@@ -73,7 +102,7 @@ RSpec.describe Falcon::Adapters::Input do
 			end
 			
 			it "can read partial input" do
-				expect(subject.read(2)).to be == ""
+				expect(subject.read(2)).to be == nil
 			end
 		end
 		


### PR DESCRIPTION
Hello @ioquatix!

I'm trying to make [tus-ruby-server](https://github.com/janko-m/tus-ruby-server) run on Falcon, as I was very impressed with its capabilities. Currently I'm recommending running tus-ruby-server on Goliath, but Goliath drags a lot of baggage which I don't need, and I needed to monkey-patch `#require` to make it work with Rack 2 (because of `async-rack`). So I would really like tus-ruby-server users to be able to use Falcon instead.

Falcon::Adapters::Input#read at the moment doesn't respect the output buffer argument when length is given. This makes IO.copy_stream not behave correctly when a Falcon::Adapters::Input object is used as the source argument. And tus-ruby-server calls IO.copy_stream on the Rack input.

This PR modifies Falcon::Adapters::Input#read to append retrieved data to the output buffer. The output buffer is now also cleared beforehand, just like in IO#read.

We also return nil when EOF was reached and length argument was given, like IO#read. When length is 0, IO#read always returns an empty string, so we handle that case as well (even though it's rather peculiar).