### PR TITLE
Reduce memory usage of Adapters::Input#read

### DIFF
--- a/falcon.gemspec
+++ b/falcon.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 	
 	spec.add_dependency('samovar', "~> 1.3")
 	
-	spec.add_development_dependency "async-rspec", "~> 1.2"
+	spec.add_development_dependency "async-rspec", "~> 1.7"
 	spec.add_development_dependency "async-websocket"
 	
 	spec.add_development_dependency "bundler", "~> 1.3"

--- a/lib/falcon/adapters/input.rb
+++ b/lib/falcon/adapters/input.rb
@@ -73,8 +73,9 @@ module Falcon
 					chunk = @buffer.slice!(0, length)
 					
 					if buffer
-						# TODO https://bugs.ruby-lang.org/issues/14745
-						buffer.replace(chunk)
+						buffer.clear
+						buffer << chunk
+						chunk.clear
 					else
 						buffer = chunk
 					end

--- a/lib/falcon/adapters/input.rb
+++ b/lib/falcon/adapters/input.rb
@@ -28,8 +28,8 @@ module Falcon
 			def initialize(body)
 				@body = body
 				
-				# The current buffer, which is extended by calling `#fill_buffer`.
-				@buffer = Async::IO::BinaryString.new
+				# Will hold remaining data in `#read`.
+				@buffer = nil
 				@finished = @body.nil?
 			end
 			
@@ -49,7 +49,7 @@ module Falcon
 				if @body
 					# If the body is not rewindable, this will fail.
 					@body.rewind
-					@buffer.clear
+					@buffer = nil
 					@finished = false
 				end
 			end
@@ -67,50 +67,41 @@ module Falcon
 			# @param buffer [String] the buffer which will receive the data
 			# @return a buffer containing the data
 			def read(length = nil, buffer = nil)
-				if length
-					fill_buffer(length) if @buffer.bytesize <= length
+				buffer ||= Async::IO::BinaryString.new
+				buffer.clear
+				
+				until buffer.length == length
+					@buffer = read_next if @buffer.nil?
+					break if @buffer.nil?
 					
-					chunk = @buffer.slice!(0, length)
+					remaining_length = length - buffer.bytesize if length
 					
-					if buffer
-						buffer.clear
-						buffer << chunk
-						chunk.clear
+					if remaining_length && remaining_length < @buffer.bytesize
+						buffer << @buffer.byteslice(0, remaining_length)
+						@buffer = @buffer.byteslice(remaining_length..-1)
 					else
-						buffer = chunk
+						buffer << @buffer
+						@buffer = nil
 					end
-					
-					if buffer.empty? and length > 0
-						return nil
-					else
-						return buffer
-					end
-				else
-					buffer ||= Async::IO::BinaryString.new
-					
-					buffer.replace(@buffer)
-					@buffer.clear
-					
-					while chunk = read_next
-						buffer << chunk
-					end
-					
-					return buffer
 				end
+				
+				return nil if buffer.empty? && length && length > 0
+				
+				return buffer
 			end
 			
 			def eof?
-				@finished and @buffer.empty?
+				@finished and @buffer.nil?
 			end
 			
 			# gets must be called without arguments and return a string, or nil on EOF.
 			# @return [String, nil] The next chunk from the body.
 			def gets
-				if @buffer.empty?
+				if @buffer.nil?
 					return read_next
 				else
-					buffer = @buffer.dup
-					@buffer.clear
+					buffer = @buffer
+					@buffer = nil
 					return buffer
 				end
 			end
@@ -130,12 +121,6 @@ module Falcon
 				else
 					@finished = true
 					return nil
-				end
-			end
-			
-			def fill_buffer(length)
-				while @buffer.bytesize < length and chunk = read_next
-					@buffer << chunk
 				end
 			end
 		end

--- a/lib/falcon/adapters/input.rb
+++ b/lib/falcon/adapters/input.rb
@@ -70,7 +70,7 @@ module Falcon
 				buffer ||= Async::IO::BinaryString.new
 				buffer.clear
 				
-				until buffer.length == length
+				until buffer.bytesize == length
 					@buffer = read_next if @buffer.nil?
 					break if @buffer.nil?
 					
@@ -81,6 +81,7 @@ module Falcon
 						@buffer = @buffer.byteslice(remaining_length..-1)
 					else
 						buffer << @buffer
+						@buffer.clear
 						@buffer = nil
 					end
 				end


### PR DESCRIPTION
`Falcon::Adapters::Input#read(length, buffer)` currently allocates memory equal to 6x the `env["rack.input"]` size. So, if Rack request body is 5MB large, then the following code which does a black-hole read:

```rb
IO.copy_stream(env["rack.input"], File::NULL)
```

currently allocates 30MB of memory in strings. This pull request reduces the memory allocated from 6x to 3x the `env["rack.input"]` size, which in this case will be 15MB.

Further memory optimizations likely have to be done on the underlying `Async::HTTP::Body` (`async-http`) and `Async::IO::Stream` (`async-io`). I would ideally like to bring memory allocations to a constant close to 0 MB. That way Falcon will be able to receive large file uploads without any additional memory cost.