### PR TITLE
remove some unuse variable warning

### DIFF
--- a/lib/falcon/adapters/rewindable.rb
+++ b/lib/falcon/adapters/rewindable.rb
@@ -56,7 +56,7 @@ module Falcon
 					request.body = Async::HTTP::Body::Rewindable.new(body)
 				end
 				
-				response = super
+				_response = super
 			end
 		end
 	end

--- a/lib/falcon/command/serve.rb
+++ b/lib/falcon/command/serve.rb
@@ -90,7 +90,7 @@ module Falcon
 			end
 			
 			def run(verbose = false)
-				app, options = load_app(verbose)
+				app, _ = load_app(verbose)
 				
 				endpoint = Endpoint.parse(@options[:bind], **endpoint_options)
 				

--- a/spec/rack/handler/falcon_spec.rb
+++ b/spec/rack/handler/falcon_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Falcon::Server do
 	
 	it "can start server" do
 		server_task = reactor.async do
-			status = Async::Process.spawn("rackup", "--server", server, "--host", host, "--port", port.to_s, config_path)
+			Async::Process.spawn("rackup", "--server", server, "--host", host, "--port", port.to_s, config_path)
 		end
 		
 		Async::Task.current.sleep 1


### PR DESCRIPTION
I realize some warning from CI result.

```
/home/travis/build/socketry/falcon/lib/falcon/command/serve.rb:93: warning: assigned but unused variable - options
/home/travis/build/socketry/falcon/lib/falcon/adapters/rewindable.rb:59: warning: assigned but unused variable - response
/home/travis/build/socketry/falcon/spec/rack/handler/falcon_spec.rb:41: warning: assigned but unused variable - status
```