### PR TITLE
fix failed spec in ruby-head

### DIFF
--- a/lib/falcon/command.rb
+++ b/lib/falcon/command.rb
@@ -41,8 +41,10 @@ module Falcon
 			end
 			
 			nested '<command>',
-				'serve' => Serve,
-				'virtual' => Virtual,
+				{
+					'serve' => Serve,
+					'virtual' => Virtual
+				},
 				default: 'serve'
 			
 			def verbose?


### PR DESCRIPTION

```
An error occurred while loading spec_helper.
Failure/Error:
  nested '<command>',
  	'serve' => Serve,
  	default: 'serve'
ArgumentError:
  non-symbol key in keyword arguments: "serve"
# ./lib/falcon/command.rb:42:in `<class:Top>'
```

Because, Ruby 2.6 Keyword arguments allow only Symbol keyword. So, Hash argument with Keyword Arugment should specify Hash Object with {}.

- https://bugs.ruby-lang.org/issues/14183
- https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=64358&view=revision

Now, I realized failed `rake benchmark:compare`. But, I would like to have another opportunity to fix this.
What do you think?