### PR TITLE
Run specs also on TruffleRuby on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,10 @@ matrix:
     - rvm: jruby-head
       env: JRUBY_OPTS="--debug -X+O"
     - rvm: ruby-head
+    - rvm: truffleruby
     - rvm: rbx-3
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
+    - rvm: truffleruby
     - rvm: rbx-3


### PR DESCRIPTION
This is just for testing. @ioquatix let me know if you will accept this as-is it or you would need something else.

TruffleRuby would work on Travis finally. https://github.com/travis-ci/travis-build/pull/1604