### PR TITLE
Fix Rack REQUEST_URI

### DIFF
--- a/lib/falcon/adapters/rack.rb
+++ b/lib/falcon/adapters/rack.rb
@@ -33,6 +33,7 @@ module Falcon
 			PATH_INFO = 'PATH_INFO'.freeze
 			REQUEST_METHOD = 'REQUEST_METHOD'.freeze
 			REQUEST_PATH = 'REQUEST_PATH'.freeze
+			REQUEST_URI = 'REQUEST_URI'.freeze
 			SCRIPT_NAME = 'SCRIPT_NAME'.freeze
 			QUERY_STRING = 'QUERY_STRING'.freeze
 			SERVER_PROTOCOL = 'SERVER_PROTOCOL'.freeze
@@ -136,7 +137,8 @@ module Falcon
 					# The remainder of the request URL's “path”, designating the virtual “location” of the request's target within the application. This may be an empty string, if the request URL targets the application root and does not have a trailing slash. This value may be percent-encoded when originating from a URL.
 					PATH_INFO => request_path,
 					REQUEST_PATH => request_path,
-					
+					REQUEST_URI => request.path,
+
 					# The portion of the request URL that follows the ?, if any. May be empty, but is always required!
 					QUERY_STRING => query_string || '',
 					

--- a/spec/falcon/adapters/rack_spec.rb
+++ b/spec/falcon/adapters/rack_spec.rb
@@ -54,7 +54,24 @@ RSpec.describe Falcon::Adapters::Rack do
 			expect(response.read).to be == "HTTP_HOST: 127.0.0.1:9294"
 		end
 	end
-	
+
+	context 'REQUEST_URI', timeout: 1 do
+		include_context Falcon::Server
+		let(:protocol) {Async::HTTP::Protocol::HTTP2}
+
+		let(:app) do
+			lambda do |env|
+				[200, {}, ["REQUEST_URI: #{env['REQUEST_URI']}"]]
+			end
+		end
+
+		let(:response) {client.get("/?foo=bar")}
+
+		it "get valid REQUEST_URI" do
+			expect(response.read).to be == "REQUEST_URI: /?foo=bar"
+		end
+	end
+
 	context 'websockets', timeout: 1 do
 		include_context Falcon::Server
 		

--- a/spec/falcon/server_context.rb
+++ b/spec/falcon/server_context.rb
@@ -1,4 +1,5 @@
 
+require "async/http/client"
 require "async/http/url_endpoint"
 
 RSpec.shared_context Falcon::Server do


### PR DESCRIPTION
Fixes an odd issue I hit today where REQUEST_URI was missing in Rack. Example:

```ruby
require "rack"
require "falcon"

builder = Rack::Builder.new
builder.map "/" do
  run lambda {|env|
    [200, {}, [env.include?("REQUEST_URI").to_s]]
  }
end

Rack::Handler.get(:falcon).run(builder.to_app)
```

I would expect this to return `true` like the example below, but returned `false`.

```ruby
#!/usr/bin/env falcon --verbose serve -c

run lambda {|env|
  [200, {}, [env.include?("REQUEST_URI").to_s]]
}
```