### PR TITLE
Yield server from rack handler

### DIFF
--- a/lib/rack/handler/falcon.rb
+++ b/lib/rack/handler/falcon.rb
@@ -24,7 +24,8 @@ module Rack
 				app = ::Falcon::Adapters::Rewindable.new(app)
 				
 				server = ::Falcon::Server.new(app, endpoint, Async::HTTP::Protocol::HTTP1, SCHEME)
-				
+				yield server if block_given?
+
 				Async::Reactor.run do
 					server.run
 				end

--- a/spec/rack/handler/falcon_spec.rb
+++ b/spec/rack/handler/falcon_spec.rb
@@ -49,3 +49,29 @@ RSpec.describe Falcon::Server do
 		server_task.stop
 	end
 end
+
+require 'rack/handler/falcon'
+RSpec.describe Rack::Handler::Falcon do
+	let(:server_double) {instance_double(Falcon::Server)}
+
+	before do
+		allow(Async::Reactor).to receive(:run)
+		allow(Falcon::Server).to receive(:new).and_return(server_double)
+	end
+
+	context 'block is given' do
+		it 'yields server' do
+			expect { |block|
+				described_class.run(double(call: true), &block)
+			}.to yield_with_args(server_double)
+		end
+	end
+
+	context 'block is not given' do
+		it 'does not fail' do
+			expect { |block|
+				described_class.run(double(call: true), &block)
+			}.not_to raise_error
+		end
+	end
+end


### PR DESCRIPTION
Implements the `yield` behavior of other handlers, such as [puma](https://github.com/puma/puma/blob/36964ec42982d7b3205760bc2bf9ccf3fec8af69/lib/rack/handler/puma.rb#L71).