### PR TITLE
Modify `spec/falcon/command/serve_spec.rb` to be properly tested.

### DIFF
--- a/spec/falcon/command/serve_spec.rb
+++ b/spec/falcon/command/serve_spec.rb
@@ -21,8 +21,6 @@
 require 'falcon/command/serve'
 
 RSpec.shared_examples_for Falcon::Command::Serve do
-	let(:options) {Array.new}
-	
 	let(:command) do
 		described_class[
 			"--port", 8090,
@@ -50,6 +48,8 @@ RSpec.shared_examples_for Falcon::Command::Serve do
 end
 
 RSpec.describe Falcon::Command::Serve do
+	let(:options) { [] }
+
 	context "with custom port" do
 		include_examples Falcon::Command::Serve
 	end


### PR DESCRIPTION
Memoized helper method `options` in `shared_examples_for` always overrides the `options` with an empty array. Therefore, these test cases do not serve the primary purpose.

Removing `options` from inside of `shared_examples_for`, and moving it into `describe block` should solve this problem.
This PR is intended for this sole reason.

Thank you.
