### PR TITLE
Remove redundant assignments

### DIFF
--- a/lib/falcon/configuration.rb
+++ b/lib/falcon/configuration.rb
@@ -92,11 +92,6 @@ module Falcon
 			
 			def add(name, *parents, &block)
 				raise KeyError.new("#{name} is already set", key: name) if @environments.key?(name)
-				
-				environments = parents.map{|name| @environments.fetch(name)}
-				
-				parent = Build::Environment.combine(*environments)
-				
 				@environments[name] = merge(name, *parents, &block)
 			end
 				
@@ -143,7 +138,7 @@ module Falcon
 				
 				parent = Build::Environment.combine(*environments)
 				
-				return Build::Environment.new(parent, name: name, &block)
+				Build::Environment.new(parent, name: name, &block)
 			end
 		end
 	end


### PR DESCRIPTION
This PR basically intends to remove redundant variables and assignments.

This would remove the following warning:
```
$ bundle exec rspec
...
lib/falcon/configuration.rb:98: warning: assigned but unused variable - parent
...
```


It seems like `@environments[name]` used to be assigned directly `Build::Environment.new(parent, name: name, &block)` according to [this change](https://github.com/socketry/falcon/commit/e93d16057f3dce737f3e72eb1f98d3c114f3bf22#diff-5638772a9fac5fcea6e20a806d9d785cL187).
However, the process including the assignment of `@environments[name]` has been moved into `merge` method.
After all of this, the assignments of local vars(`environments`, `parent`)  in `add` method are not necessary.

Thank you.

---

cf. [Falcon::Configuration.merge](https://github.com/socketry/falcon/blob/master/lib/falcon/configuration.rb#L141)

