### PR TITLE
Improve the indentation of rails 3 example class

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,3 @@
 # These are supported funding model platforms
 custom: https://github.com/socketry/community/#funding
+github: ioquatix

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem "async-container", path: "../async-container"
+
 group :development do
 	gem 'ruby-prof', platform: :mri
 end

--- a/README.md
+++ b/README.md
@@ -138,12 +138,12 @@ Please ensure you specify `config.threadsafe!` in your `config/application.rb`:
 
 ```ruby
 module MySite
-	class Application < Rails::Application
-		# ...
+  class Application < Rails::Application
+    # ...
 		
-		# Enable threaded mode
-		config.threadsafe!
-	end
+    # Enable threaded mode
+    config.threadsafe!
+  end
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Falcon is a multi-process, multi-fiber rack-compatible HTTP server built on top 
 [![Build Status](https://travis-ci.com/socketry/falcon.svg)](http://travis-ci.com/socketry/falcon)
 [![Code Climate](https://codeclimate.com/github/socketry/falcon.svg)](https://codeclimate.com/github/socketry/falcon)
 [![Coverage Status](https://coveralls.io/repos/socketry/falcon/badge.svg)](https://coveralls.io/r/socketry/falcon)
-[![Gitter](https://badges.gitter.im/join.svg)](https://gitter.im/socketry/falcon)
+[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/async/falcon)
 
 [async]: https://github.com/socketry/async
 [async-io]: https://github.com/socketry/async-io

--- a/examples/beer/falcon.rb
+++ b/examples/beer/falcon.rb
@@ -3,3 +3,5 @@
 load :rack, :self_signed_tls, :supervisor
 
 rack 'beer.localhost', :self_signed_tls
+
+supervisor

--- a/falcon.gemspec
+++ b/falcon.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
 		
 	spec.add_dependency "async", "~> 1.13"
 	spec.add_dependency "async-io", "~> 1.22"
-	spec.add_dependency "async-http", "~> 0.48.0"
-	spec.add_dependency "async-container", "~> 0.14.0"
+	spec.add_dependency "async-http", "~> 0.49.0"
+	spec.add_dependency "async-container", "~> 0.15.0"
 	
 	spec.add_dependency "rack", ">= 1.0"
 	

--- a/lib/falcon/command/host.rb
+++ b/lib/falcon/command/host.rb
@@ -74,6 +74,14 @@ module Falcon
 			def call(container = Async::Container.new)
 				container = run(container, parent&.verbose?)
 				
+				Signal.trap(:USR2) do
+					replacement = run(container.class.new, parent&.verbose?)
+					
+					container.stop
+					
+					container = replacement
+				end
+				
 				container.wait(true)
 			end
 		end

--- a/lib/falcon/command/virtual.rb
+++ b/lib/falcon/command/virtual.rb
@@ -91,6 +91,9 @@ module Falcon
 			def call
 				container = run(parent.verbose?)
 				
+				# If we are asked to restart a given container, spawn a new container to replace the old one.
+				
+				
 				container.wait
 			end
 			

--- a/lib/falcon/supervisor.rb
+++ b/lib/falcon/supervisor.rb
@@ -70,6 +70,12 @@ module Falcon
 		end
 		
 		def restart(message)
+			# Tell the parent of this process group to spin up a new process group/container.
+			# Wait for that to start accepting new connections.
+			# Stop accepting connections.
+			# Wait for existing connnections to drain.
+			# Terminate this process group.
+			
 			signal = message[:signal] || :INT
 			
 			# Sepukku:

--- a/spec/falcon/command/serve_spec.rb
+++ b/spec/falcon/command/serve_spec.rb
@@ -29,7 +29,7 @@ RSpec.shared_examples_for Falcon::Command::Serve do
 	end
 	
 	it "can listen on specified port" do
-		container = command.run(true)
+		controller = command.run(true)
 		
 		begin
 			Async do
@@ -42,7 +42,7 @@ RSpec.shared_examples_for Falcon::Command::Serve do
 				client.close
 			end
 		ensure
-			container.stop(false)
+			controller.stop(false)
 		end
 	end
 end

--- a/spec/falcon/command/top_spec.rb
+++ b/spec/falcon/command/top_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe Falcon::Command::Top do
 				expect(response).to be_success
 				
 				response.finish
-				
 				client.close
 			end
 			


### PR DESCRIPTION
GitHub was rendering as a tab spaced ruby code, with this change is a real two space ruby class :D