### PR TITLE
Add a count to Application so that process count can be controlled in falcon host

### DIFF
--- a/lib/falcon/environments/application.rb
+++ b/lib/falcon/environments/application.rb
@@ -65,4 +65,8 @@ environment(:application) do
 	# The service class to use for the application.
 	# @attribute [Class]
 	service ::Falcon::Service::Application
+	
+	# Number of instances to start.
+	# @attribute [Integer | nil]
+	count nil
 end

--- a/lib/falcon/service/application.rb
+++ b/lib/falcon/service/application.rb
@@ -42,6 +42,12 @@ module Falcon
 				@environment.evaluator.middleware
 			end
 			
+			# Number of instances to start.
+			# @returns [Integer | nil]
+			def count
+			  @environment.evaluator.count
+			end
+			
 			# Preload any resources specified by the environment.
 			def preload!
 				if scripts = @evaluator.preload
@@ -73,7 +79,14 @@ module Falcon
 				protocol = self.protocol
 				scheme = self.scheme
 				
-				container.run(name: self.name, restart: true) do |instance|
+				run_options = {
+					name: self.name,
+					restart: true,
+				}
+				
+				run_options[:count] = count unless count.nil?
+				
+				container.run(**run_options) do |instance|
 					Async(logger: logger) do |task|
 						Async.logger.info(self) {"Starting application server for #{self.root}..."}
 						

--- a/spec/falcon/configuration_spec.rb
+++ b/spec/falcon/configuration_spec.rb
@@ -28,4 +28,10 @@ RSpec.describe Falcon::Configuration do
 		
 		expect(subject.environments).to include('localhost')
 	end
+	
+	it "can configure rack" do
+		subject.load_file(File.expand_path("configuration_spec/rack.rb", __dir__))
+		
+		expect(subject.environments).to include('localhost')
+	end
 end

--- a/spec/falcon/configuration_spec/rack.rb
+++ b/spec/falcon/configuration_spec/rack.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+load :rack
+
+rack 'localhost' do
+  count 3
+end


### PR DESCRIPTION
In situations where the processor count reported by linux doesn't reflect the actual resources available or where the relative impact of memory to CPU is high it is necessary to manually control the number of processes created.

For example, I have an application deployed with kubernetes which has a resource limit of 4 cores, but the `Etc.nprocessors` is 36, which would result in an extraordinarily high memory footprint for the available CPU.

While `falcon serve` provides the capability to configure the number of processes, `falcon host` does not and `falcon serve` is discouraged in production by the documentation.

This change adds a `count` attribute to Service::Application and its subclasses and environments and passes the value to `container.run` if present.

I did attempt to update the documentation; however `bake utopia:project:static` simply deletes all documentation when I attempt to use it.
