### PR TITLE
Fix a couple of warnings.

### DIFF
--- a/lib/falcon/configuration.rb
+++ b/lib/falcon/configuration.rb
@@ -198,7 +198,7 @@ module Falcon
 			# @parameter parents [Array(Build::Environment)]
 			# @yields {...} The block that will generate the environment.
 			def merge(name, *parents, &block)
-				environments = parents.map{|name| @environments.fetch(name)}
+				environments = parents.map{|env_name| @environments.fetch(env_name)}
 				
 				parent = Build::Environment.combine(*environments)
 				

--- a/lib/falcon/middleware/verbose.rb
+++ b/lib/falcon/middleware/verbose.rb
@@ -54,8 +54,8 @@ module Falcon
 				
 				response = super
 				
-				statistics.wrap(response) do |statistics, error|
-					@logger.info(request) {"Responding with: #{response.status} #{response.headers.to_h}; #{statistics.inspect}"}
+				statistics.wrap(response) do |response_statistics, error|
+					@logger.info(request) {"Responding with: #{response.status} #{response.headers.to_h}; #{response_statistics.inspect}"}
 					
 					@logger.error(request) {"#{error.class}: #{error.message}"} if error
 				end


### PR DESCRIPTION
Fix a couple of warnings when running specs:
```
/Users/michael/Code/Socketry/falcon/lib/falcon/middleware/verbose.rb:57: warning: shadowing outer local variable - statistics
/Users/michael/Code/Socketry/falcon/lib/falcon/configuration.rb:201: warning: shadowing outer local variable - name
```

## Types of Changes

<!-- Put an `x` in all the boxes that apply: -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.

## Testing

<!-- Put an `x` in all the boxes that apply: -->
- [ ] I added new tests for my changes.
- [x] I ran all the tests locally.
