### PR TITLE
Add listening message

### DIFF
--- a/lib/falcon/controller/serve.rb
+++ b/lib/falcon/controller/serve.rb
@@ -68,6 +68,8 @@ module Falcon
 					Async::IO::SharedEndpoint.bound(@endpoint)
 				end.wait
 				
+				Async.logger.info(self) { "Starting #{name} on #{@endpoint.to_url}" }
+				
 				@debug_trap.ignore!
 				
 				super

--- a/lib/falcon/version.rb
+++ b/lib/falcon/version.rb
@@ -21,5 +21,5 @@
 # THE SOFTWARE.
 
 module Falcon
-	VERSION = "0.36.5"
+	VERSION = "0.36.6"
 end


### PR DESCRIPTION
Previously when starting Falcon-guard, a startup message would be printed, e.g.: `Starting Falcon HTTP server on localhost:9292`. However since Falcon-guard 0.10 the bulk of the logic has been moved into `Falcon::Controller::Serve` and the startup message has been lost. I'm not sure if this message belongs in here or in Falcon-guard, however I placed it here to keep the Falcon guard implementation minimal. Happy to move it though if it belongs there more?

## Types of Changes

<!-- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.

## Testing

<!-- Put an `x` in all the boxes that apply: -->
- [ ] I added new tests for my changes.
- [x] I ran all the tests locally.
