### PR TITLE
Add missing require in ssl server spec

### DIFF
--- a/spec/falcon/ssl_server_spec.rb
+++ b/spec/falcon/ssl_server_spec.rb
@@ -22,6 +22,7 @@
 
 require 'falcon/server'
 require 'async/http/client'
+require 'async/http/endpoint'
 require 'async/rspec/reactor'
 require 'async/rspec/ssl'
 


### PR DESCRIPTION
I stumbled upon this last week when running the rack test suite. It seems that if you run the falcon tests all at once everything is good but if you try to run this single test you get a NameError as `Async::HTTP::Endpoint` is not included.