### PR TITLE
Add support for callable bodies.

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -5,7 +5,6 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ${{matrix.os}}-latest
-    continue-on-error: ${{matrix.experimental}}
     
     strategy:
       matrix:
@@ -45,5 +44,6 @@ jobs:
       run: sudo apt-get install apache2-utils openssl
     
     - name: Run tests
+      continue-on-error: ${{matrix.experimental}}
       timeout-minutes: 5
       run: ${{matrix.env}} bundle exec rspec

--- a/gems.rb
+++ b/gems.rb
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem "rack", git: 'https://github.com/ioquatix/rack', branch: 'streaming'
+
 # gem "async-container", path: "../async-container"
 # gem "async-websocket", path: "../async-websocket"
 # gem "async-http", path: "../async-http"

--- a/lib/falcon/adapters/response.rb
+++ b/lib/falcon/adapters/response.rb
@@ -81,7 +81,7 @@ module Falcon
 						Console.logger.warn("Ignoring protocol-level headers: #{ignored.inspect}")
 					end
 					
-					body = Output.wrap(status, headers, body)
+					body = Output.wrap(status, headers, body, request)
 				end
 				
 				if request&.head?

--- a/spec/falcon/adapters/rack_spec.rb
+++ b/spec/falcon/adapters/rack_spec.rb
@@ -128,4 +128,25 @@ RSpec.describe Falcon::Adapters::Rack do
 			connection.close
 		end
 	end
+	
+	context 'streaming' do
+		include_context Falcon::Server
+		
+		let(:app) do
+			lambda do |env|
+				body = lambda do |stream|
+					stream.write("Hello Streaming World")
+					stream.close
+				end
+				
+				[200, {}, body]
+			end
+		end
+		
+		let(:response) {client.get("/")}
+		
+		it "can read streaming response" do
+			expect(response.read).to be == "Hello Streaming World"
+		end
+	end
 end

--- a/spec/falcon/adapters/response_spec.rb
+++ b/spec/falcon/adapters/response_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Falcon::Adapters::Response do
 	end
 	
 	context 'with #to_path' do
-		let(:body) {double}
+		let(:body) {Array.new}
 		
 		it "should generate file body" do
 			expect(body).to receive(:to_path).and_return("/dev/null")


### PR DESCRIPTION
## Description

Add support for callable bodies for streaming responses.

``` ruby
app = lambda do |env|
	body = lambda do |stream|
		stream.write("Hello Streaming World")
		stream.close
	end
	
	[200, {}, body]
end

run app
```

### Types of Changes

- New feature.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
