### PR TITLE
Avoid "shadowing outer local variable - statistics"

### DIFF
--- a/lib/falcon/middleware/verbose.rb
+++ b/lib/falcon/middleware/verbose.rb
@@ -54,8 +54,8 @@ module Falcon
 				
 				response = super
 				
-				statistics.wrap(response) do |statistics, error|
-					@logger.info(request) {"Responding with: #{response.status} #{response.headers.to_h}; #{statistics.inspect}"}
+				statistics.wrap(response) do |stats, error|
+					@logger.info(request) {"Responding with: #{response.status} #{response.headers.to_h}; #{stats.inspect}"}
 					
 					@logger.error(request) {"#{error.class}: #{error.message}"} if error
 				end


### PR DESCRIPTION
## Description

This PR attempts to avoid an emitted Ruby warning

    warning: shadowing outer local variable - statistics

### Types of Changes

- Maintenance.

### Testing

...