### PR TITLE
Make restart an option

### DIFF
--- a/lib/falcon/command/serve.rb
+++ b/lib/falcon/command/serve.rb
@@ -66,6 +66,7 @@ module Falcon
 				
 				option '--forks <count>', "Number of forks (hybrid only).", type: Integer
 				option '--threads <count>', "Number of threads (hybrid only).", type: Integer
+				option '--restart <true|false>', "Enable or disable automatic restart. Enabled by default.", default: true
 			end
 			
 			# The container class to use.
@@ -103,7 +104,7 @@ module Falcon
 			# Options for the container.
 			# See {Controller::Serve#setup}.
 			def container_options
-				@options.slice(:count, :forks, :threads)
+				@options.slice(:count, :forks, :threads).merge(restart: @options[:restart] != "false")
 			end
 			
 			# Options for the {endpoint}.

--- a/lib/falcon/controller/serve.rb
+++ b/lib/falcon/controller/serve.rb
@@ -83,7 +83,7 @@ module Falcon
 			# Setup the container with the application instance.
 			# @parameter container [Async::Container::Generic]
 			def setup(container)
-				container.run(name: self.name, restart: true, **@command.container_options) do |instance|
+				container.run(name: self.name, **@command.container_options) do |instance|
 					Async do |task|
 						# Load one app instance per container:
 						app = self.load_app


### PR DESCRIPTION
When using falcon serve the controller keeps restarting the process if there is a syntax error.

This commit adds a --restart false option to falcon serve so that it doesn't restart repeatedly.

This keeps the default restart: true behavior.

<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
-->

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
