### PR TITLE
Add support for streaming bodies and by implication WebSockets.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,6 @@ jobs:
   test:
     name: ${{matrix.ruby}} on ${{matrix.os}}
     runs-on: ${{matrix.os}}-latest
-    continue-on-error: ${{matrix.experimental}}
     
     strategy:
       matrix:

--- a/falcon.gemspec
+++ b/falcon.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 	
 	spec.add_dependency "async"
 	spec.add_dependency "async-container", "~> 0.16.0"
-	spec.add_dependency "async-http", "~> 0.56.0"
+	spec.add_dependency "async-http", "~> 0.57.0"
 	spec.add_dependency "async-http-cache", "~> 0.4.0"
 	spec.add_dependency "async-io", "~> 1.22"
 	spec.add_dependency "build-environment", "~> 1.13"
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
 	
 	spec.add_development_dependency "async-process", "~> 1.1"
 	spec.add_development_dependency "async-rspec", "~> 1.7"
-	spec.add_development_dependency "async-websocket", "~> 0.14.0"
+	spec.add_development_dependency "async-websocket", "~> 0.19.2"
 	spec.add_development_dependency "bake"
 	spec.add_development_dependency "covered"
 	spec.add_development_dependency "rspec", "~> 3.6"

--- a/gems.rb
+++ b/gems.rb
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem "rack", git: 'https://github.com/ioquatix/rack', branch: 'streaming'
+
 # gem "async-container", path: "../async-container"
 # gem "async-websocket", path: "../async-websocket"
 # gem "async-http", path: "../async-http"

--- a/gems.rb
+++ b/gems.rb
@@ -4,8 +4,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-# gem "rack", git: 'https://github.com/ioquatix/rack', branch: 'streaming'
-
 # gem "async-container", path: "../async-container"
 # gem "async-websocket", path: "../async-websocket"
 # gem "async-http", path: "../async-http"

--- a/gems.rb
+++ b/gems.rb
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "rack", git: 'https://github.com/ioquatix/rack', branch: 'streaming'
+# gem "rack", git: 'https://github.com/ioquatix/rack', branch: 'streaming'
 
 # gem "async-container", path: "../async-container"
 # gem "async-websocket", path: "../async-websocket"

--- a/lib/falcon/adapters/response.rb
+++ b/lib/falcon/adapters/response.rb
@@ -81,7 +81,7 @@ module Falcon
 						Console.logger.warn("Ignoring protocol-level headers: #{ignored.inspect}")
 					end
 					
-					body = Output.wrap(status, headers, body)
+					body = Output.wrap(status, headers, body, request)
 				end
 				
 				if request&.head?

--- a/spec/falcon/adapters/rack_spec.rb
+++ b/spec/falcon/adapters/rack_spec.rb
@@ -117,15 +117,12 @@ RSpec.describe Falcon::Adapters::Rack do
 		end
 		
 		it "can send and receive messages using websockets" do
-			client = Async::WebSocket::Client.open(endpoint)
-			connection = client.connect(endpoint.path)
-			
-			connection.write(test_message)
-			
-			message = connection.read
-			expect(message).to be == test_message
-			
-			connection.close
+			Async::WebSocket::Client.connect(endpoint) do |connection|
+				connection.write(test_message)
+				
+				message = connection.read
+				expect(message).to be == test_message
+			end
 		end
 	end
 	

--- a/spec/falcon/adapters/rack_spec.rb
+++ b/spec/falcon/adapters/rack_spec.rb
@@ -128,4 +128,25 @@ RSpec.describe Falcon::Adapters::Rack do
 			connection.close
 		end
 	end
+	
+	context 'streaming' do
+		include_context Falcon::Server
+		
+		let(:app) do
+			lambda do |env|
+				body = lambda do |stream|
+					stream.write("Hello Streaming World")
+					stream.close
+				end
+				
+				[200, {}, body]
+			end
+		end
+		
+		let(:response) {client.get("/")}
+		
+		it "can read streaming response" do
+			expect(response.read).to be == "Hello Streaming World"
+		end
+	end
 end

--- a/spec/falcon/adapters/response_spec.rb
+++ b/spec/falcon/adapters/response_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Falcon::Adapters::Response do
 	end
 	
 	context 'with #to_path' do
-		let(:body) {double}
+		let(:body) {Array.new}
 		
 		it "should generate file body" do
 			expect(body).to receive(:to_path).and_return("/dev/null")


### PR DESCRIPTION
This is an MVP to get streaming working according to the new spec in Rack 3, without actually adopting Rack 3.

While WebSockets current work, they do so by responding with an `Async::HTTP::Body` wrapper. Any instance of `BodyProxy` will cause failure. Let's try to address that first, as it's a useful stepping stone to full Rack 3 support.

### Types of Changes

- New feature.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
