### PR TITLE
Mention Rails 7.1 isolation_level config

### DIFF
--- a/guides/rails-integration/README.md
+++ b/guides/rails-integration/README.md
@@ -9,6 +9,17 @@ Because `rails` apps are built on top of `rack`, they are compatible with `falco
 1. Add `gem 'falcon'` to your `Gemfile` and perhaps remove `gem 'puma'` once you are satisfied with the change.
 2. Run `falcon serve` to start a local development server.
 
+## Isolation Level
+
+Rails 7.1 introduced the ability to change its internal isolation level from threads (default) to fibers.
+
+Make sure to configure it to fibers:
+```ruby
+# config/application.rb
+
+config.active_support.isolation_level = :fiber
+```
+
 ## Thread Safety
 
 With older versions of Rails, the `Rack::Lock` middleware can be inserted into your app by Rails. `Rack::Lock` will cause both poor performance and deadlocks due to the highly concurrent nature of `falcon`. Other web frameworks are generally unaffected.


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

The other day I was trying Falcon for the first time on a I/O bound Rails app. While I was testing I started seeing very strange errors when doing simple DB queries (PostgreSQL), for example primary_key not found for table x. Fortunately, after some research, I realized I needed switch a new Rails 7.1 config. When I did that I was amazed to see how everything started to work just fine, and feeling grateful we have an evented web server ready to be used along with Rails (thanks 🙌).

I added the config change to the top of the docs so we make sure nobody makes the same mistake, but I'm wondering if this should be turned on automatically by falcon using a Railtie?

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Documentation

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
