### PR TITLE
Ensure `isolation_level` is set.

### DIFF
--- a/lib/falcon.rb
+++ b/lib/falcon.rb
@@ -4,3 +4,6 @@
 # Copyright, 2017-2023, by Samuel Williams.
 
 require_relative "falcon/server"
+
+# Falcon, running on Rails, requires specific configuration:
+require_relative "falcon/railtie" if defined?(Rails::Railtie)

--- a/lib/falcon/railtie.rb
+++ b/lib/falcon/railtie.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Falcon
+	class Railtie < Rails::Railtie
+		config.active_support.isolation_level = :fiber
+	end
+end


### PR DESCRIPTION
To avoid potential mis-configuration when used with rails, we can use a railtie to set the `isolation_level` correctly.

See https://github.com/socketry/falcon/pull/218 for more context.

I don't like how we are (optionally) coupling falcon to Rails, but I'm not sure there is a good alternative. I considered a separate gem, but people may miss it.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
