### PR TITLE
Add more docs re: Rails

### DIFF
--- a/guides/rails-integration/readme.md
+++ b/guides/rails-integration/readme.md
@@ -13,6 +13,12 @@ Because `rails` apps are built on top of `rack`, they are compatible with `falco
 
 Rails 7.1 introduced the ability to change its internal isolation level from threads (default) to fibers. When you use `falcon` with Rails, it will automatically set the isolation level to fibers.
 
+Beware that this change may increase the utilization of shared resources such as Active Record's connection pool. If you'd like to retain the default behavior, add the following to `config/application.rb` to reset the isolation level to threads:
+
+~~~ ruby
+config.active_support.isolation_level = :thread
+~~~
+
 ## Thread Safety
 
 With older versions of Rails, the `Rack::Lock` middleware can be inserted into your app by Rails. `Rack::Lock` will cause both poor performance and deadlocks due to the highly concurrent nature of `falcon`. Other web frameworks are generally unaffected.
@@ -25,7 +31,7 @@ Please ensure you specify `config.threadsafe!` in your `config/application.rb`:
 module MySite
 	class Application < Rails::Application
 		# ...
-		
+
 		# Enable threaded mode
 		config.threadsafe!
 	end

--- a/guides/rails-integration/readme.md
+++ b/guides/rails-integration/readme.md
@@ -11,9 +11,19 @@ Because `rails` apps are built on top of `rack`, they are compatible with `falco
 
 ## Isolation Level
 
-Rails 7.1 introduced the ability to change its internal isolation level from threads (default) to fibers. When you use `falcon` with Rails, it will automatically set the isolation level to fibers.
+Rails 7.1 introduced the ability to change its internal isolation level from threads (default) to fibers. When you use `falcon` with Rails, it will automatically set the isolation level to fibers to improve performance.
 
-Beware that this change may increase the utilization of shared resources such as Active Record's connection pool. If you'd like to retain the default behavior, add the following to `config/application.rb` to reset the isolation level to threads:
+Beware that this change may increase the utilization of shared resources such as Active Record's connection pool, since you'll likely be running many more fibers than threads. In the future, Rails is likely to improve connection pool handling so this shouldn't be an issue in practice.
+
+To mitigate this issue in the meantime, you can wrap Active Record calls in a `with_connection` block so they're released at the end of the block, as opposed to waiting for the Rails server to finish returning the response:
+
+~~~ ruby
+ActiveRecord::Base.connection_pool.with_connection do
+  Example.find(1)
+end
+~~~
+
+Or to simply retain the default Rails behavior, add the following to `config/application.rb` to reset the isolation level to threads:
 
 ~~~ ruby
 config.active_support.isolation_level = :thread

--- a/guides/rails-integration/readme.md
+++ b/guides/rails-integration/readme.md
@@ -13,9 +13,9 @@ Because `rails` apps are built on top of `rack`, they are compatible with `falco
 
 Rails 7.1 introduced the ability to change its internal isolation level from threads (default) to fibers. When you use `falcon` with Rails, it will automatically set the isolation level to fibers to improve performance.
 
-Beware that this change may increase the utilization of shared resources such as Active Record's connection pool, since you'll likely be running many more fibers than threads. In the future, Rails is likely to improve connection pool handling so this shouldn't be an issue in practice.
+Beware that this change may increase the utilization of shared resources such as Active Record's connection pool, since you'll likely be running many more fibers than threads. In the future, Rails is likely to adjust connection pool handling so this shouldn't be an issue in practice.
 
-To mitigate this issue in the meantime, you can wrap Active Record calls in a `with_connection` block so they're released at the end of the block, as opposed to waiting for the Rails server to finish returning the response:
+To mitigate the issue in the meantime, you can wrap Active Record calls in a `with_connection` block so they're released at the end of the block, as opposed to the default behavior where Rails keeps the connection checked out until its finished returning the response:
 
 ~~~ ruby
 ActiveRecord::Base.connection_pool.with_connection do


### PR DESCRIPTION
Add a bit more documentation around the `isolation_level` change from #219, including an example to retain the default behavior in Rails. 

My concern is that with Rails <= 7.1.3 database connections are checked out until the response is sent back to the client. So, if you have a limited connection pool (as you might on Heroku etc) you might exhaust your limit unexpectedly if you have long-running fibers. In the future, Rails is likely to improve connection pool handling so this shouldn't be an issue in practice for long, but for now it seems prudent to document.

See #219 and #218 for more context, note links to other issues with other potential workarounds such as wrapping database queries in a `with_connection` block. 

## Types of Changes

- Documentation

## Contribution

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
