### PR TITLE
Update Rails isolation_level docs with new learnings

### DIFF
--- a/guides/rails-integration/readme.md
+++ b/guides/rails-integration/readme.md
@@ -11,9 +11,9 @@ Because `rails` apps are built on top of `rack`, they are compatible with `falco
 
 ## Isolation Level
 
-Rails 7.1 introduced the ability to change its internal isolation level from threads (default) to fibers. When you use `falcon` with Rails, it will automatically set the isolation level to fibers to improve performance.
+Rails 7.1 introduced the ability to change its internal isolation level from threads (default) to fibers. When you use `falcon` with Rails, it will automatically set the isolation level to fibers.
 
-Beware that this change may increase the utilization of shared resources such as Active Record's connection pool, since you'll likely be running many more fibers than threads. In the future, Rails is likely to adjust connection pool handling so this shouldn't be an issue in practice.
+Beware that changing the isolation level may increase the utilization of shared resources such as Active Record's connection pool, since you'll likely be running many more fibers than threads. In the future, Rails is likely to adjust connection pool handling so this shouldn't be an issue in practice.
 
 To mitigate the issue in the meantime, you can wrap Active Record calls in a `with_connection` block so they're released at the end of the block, as opposed to the default behavior where Rails keeps the connection checked out until its finished returning the response:
 
@@ -23,7 +23,7 @@ ActiveRecord::Base.connection_pool.with_connection do
 end
 ~~~
 
-Or to simply retain the default Rails behavior, add the following to `config/application.rb` to reset the isolation level to threads:
+Alternatively, to retain the default Rails behavior, you can add the following to `config/application.rb` to reset the isolation level to threads, but beware that sharing connections between fibers may result in unexpected errors within Active Record and is not recommended:
 
 ~~~ ruby
 config.active_support.isolation_level = :thread


### PR DESCRIPTION
Following up on #220 after encountering unexpected errors when retaining `isolation_level = :thread` in a high-traffic production application being upgraded from Rails 7.0.8 -> 7.1.3.

My suggestion is to leave the documentation mostly in place, but to clarify that retaining `:thread` is not recommended after my practical experience. See https://github.com/socketry/falcon/pull/220#issuecomment-1924727682 for a bit more detail including the types of errors I was seeing in production. 

## Types of Changes

- Documentation

## Contribution

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
