### PR TITLE
Fix construction of Rack applications on Rack < 3

### DIFF
--- a/lib/falcon/environment/rackup.rb
+++ b/lib/falcon/environment/rackup.rb
@@ -14,8 +14,14 @@ module Falcon
 				'config.ru'
 			end
 			
-			def rack_app
-				::Rack::Builder.parse_file(rackup_path)
+			if Gem::Version.new(Rack::RELEASE) < Gem::Version.new("3")
+				def rack_app
+					::Rack::Builder.parse_file(rackup_path).first
+				end
+			else
+				def rack_app
+					::Rack::Builder.parse_file(rackup_path)
+				end
 			end
 			
 			def middleware


### PR DESCRIPTION
Rack::Builder in Rack 2 returns a 2 element tuple, instead of a single element.

If using Rack 2.x, define a method that returns a single element.

Closes #230

## Types of Changes

- Bug fix.

## Contribution

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
