### PR TITLE
Heroku example for the Deployment Guide

### DIFF
--- a/guides/deployment/readme.md
+++ b/guides/deployment/readme.md
@@ -95,8 +95,7 @@ service hostname do
 	# If using count > 1 you may want to preload your app to reduce memory usage and increase performance:
 	preload "preload.rb"
 
-	# Heroku only supports HTTP/1.1 at the time of this writing.
-	# Review the following for possible updates in the future:
+	# Heroku only supports HTTP/1.1 at the time of this writing. Review the following for possible updates in the future:
 	# https://devcenter.heroku.com/articles/http-routing#http-versions-supported
 	# https://github.com/heroku/roadmap/issues/34
 	endpoint Async::HTTP::Endpoint.parse("http://0.0.0.0:#{port}").with(protocol: Async::HTTP::Protocol::HTTP11)

--- a/guides/deployment/readme.md
+++ b/guides/deployment/readme.md
@@ -84,24 +84,21 @@ hostname = File.basename(__dir__)
 port = ENV["PORT"] || 3000
 
 service hostname do
-  include Falcon::Environment::Rack
+	include Falcon::Environment::Rack
 
 	# By default, Falcon uses Etc.nprocessors to set the count, which is likely incorrect on shared hosts like Heroku.
 	# Review the following for guidance about how to find the right value for your app:
 	# https://help.heroku.com/88G3XLA6/what-is-an-acceptable-amount-of-dyno-load
 	# https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#workers
-	#
 	count ENV.fetch("WEB_CONCURRENCY", 1).to_i
 
 	# If using count > 1 you may want to preload your app to reduce memory usage and increase performance:
-	#
 	preload "preload.rb"
 
 	# Heroku only supports HTTP/1.1 at the time of this writing.
 	# Review the following for possible updates in the future:
 	# https://devcenter.heroku.com/articles/http-routing#http-versions-supported
 	# https://github.com/heroku/roadmap/issues/34
-	#
 	endpoint Async::HTTP::Endpoint.parse("http://0.0.0.0:#{port}").with(protocol: Async::HTTP::Protocol::HTTP11)
 end
 ~~~

--- a/guides/deployment/readme.md
+++ b/guides/deployment/readme.md
@@ -26,7 +26,7 @@ hostname = File.basename(__dir__)
 service hostname do
 	include Falcon::Environment::Rack
 	include Falcon::Environment::LetsEncryptTLS
-	
+
 	# Insert an in-memory cache in front of the application (using async-http-cache).
 	cache true
 end
@@ -50,7 +50,7 @@ hostname = File.basename(__dir__)
 service hostname do
 	include Falcon::Environment::Rack
 	include Falcon::Environment::LetsEncryptTLS
-	
+
 	endpoint do
 		Async::HTTP::Endpoint.parse('http://localhost:3000').with(protocol: Async::HTTP::Protocol::HTTP2)
 	end
@@ -62,6 +62,42 @@ end
 ~~~
 
 You can verify this is working using `nghttp -v http://localhost:3000`.
+
+#### Application Configuration Example for Heroku
+
+Building on the examples above, the following is a full configuration example for Heroku:
+
+~~~ bash
+# Procfile
+
+web: bundle exec falcon host
+~~~
+
+~~~ ruby
+# falcon.rb
+
+#!/usr/bin/env -S falcon host
+
+load :rack
+
+hostname = File.basename(__dir__)
+port = ENV["PORT"] || 3000
+
+service hostname do
+  include Falcon::Environment::Rack
+
+  append preload "preload.rb" # optional
+  cache false # optional
+  count ENV.fetch("FALCON_COUNT", 1).to_i # defaults to Etc.nprocessors, which is likely incorrect on shared hosts like Heroku
+  endpoint Async::HTTP::Endpoint.parse("http://0.0.0.0:#{port}").with(protocol: Async::HTTP::Protocol::HTTP11)
+end
+~~~
+
+~~~ ruby
+# preload.rb
+
+require_relative "config/environment"
+~~~
 
 ## Falcon Virtual
 

--- a/guides/deployment/readme.md
+++ b/guides/deployment/readme.md
@@ -86,10 +86,23 @@ port = ENV["PORT"] || 3000
 service hostname do
   include Falcon::Environment::Rack
 
-  append preload "preload.rb" # optional
-  cache false # optional
-  count ENV.fetch("FALCON_COUNT", 1).to_i # defaults to Etc.nprocessors, which is likely incorrect on shared hosts like Heroku
-  endpoint Async::HTTP::Endpoint.parse("http://0.0.0.0:#{port}").with(protocol: Async::HTTP::Protocol::HTTP11)
+	# By default, Falcon uses Etc.nprocessors to set the count, which is likely incorrect on shared hosts like Heroku.
+	# Review the following for guidance about how to find the right value for your app:
+	# https://help.heroku.com/88G3XLA6/what-is-an-acceptable-amount-of-dyno-load
+	# https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#workers
+	#
+	count ENV.fetch("WEB_CONCURRENCY", 1).to_i
+
+	# If using count > 1 you may want to preload your app to reduce memory usage and increase performance:
+	#
+	preload "preload.rb"
+
+	# Heroku only supports HTTP/1.1 at the time of this writing.
+	# Review the following for possible updates in the future:
+	# https://devcenter.heroku.com/articles/http-routing#http-versions-supported
+	# https://github.com/heroku/roadmap/issues/34
+	#
+	endpoint Async::HTTP::Endpoint.parse("http://0.0.0.0:#{port}").with(protocol: Async::HTTP::Protocol::HTTP11)
 end
 ~~~
 


### PR DESCRIPTION
Re: https://github.com/socketry/falcon-rails-example/issues/1, adding some documentation to show a full working example Heroku configuration for Falcon. 

Note I wasn't sure where to put this, but I believe this could be a reasonable place. I also tried to follow the new configuration style in the guides, but feedback is welcome. 

Note also that I included preload, cache, and count config examples which may or may not be desirable. I'm happy to adjust. We could also adjust to use a different ENV var etc as opposed to `FALCON_COUNT` -- feel free to adjust as you like, or let me know what you'd prefer and I'll make adjustments. 

Fixes https://github.com/socketry/falcon/issues/189
Fixes https://github.com/socketry/falcon/issues/121

## Types of Changes

- Documentation.

## Contribution

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
