### PR TITLE
Resolve (glob) configuration paths.

### DIFF
--- a/lib/falcon/command/virtual.rb
+++ b/lib/falcon/command/virtual.rb
@@ -3,8 +3,7 @@
 # Released under the MIT License.
 # Copyright, 2018-2024, by Samuel Williams.
 
-require_relative '../service/virtual'
-require_relative 'paths'
+require_relative '../environment/virtual'
 
 require 'samovar'
 
@@ -31,7 +30,7 @@ module Falcon
 			many :paths
 			
 			def environment
-				Async::Service::Environment.new(Falcon::Service::Virtual::Environment).with(
+				Async::Service::Environment.new(Falcon::Environment::Virtual).with(
 					verbose: self.parent&.verbose?,
 					configuration_paths: self.paths,
 					bind_insecure: @options[:bind_insecure],

--- a/lib/falcon/environment/configured.rb
+++ b/lib/falcon/environment/configured.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
+module Falcon
+	module Environment
+		# This module provides a common interface for configuring the Falcon application.
+		# @todo Reuse this for proxy and redirect services.
+		module Configured
+			# All the falcon application configuration paths.
+			# @returns [Array(String)] Paths to the falcon application configuration files.
+			def configuration_paths
+				["/srv/http/*/falcon.rb"]
+			end
+			
+			# All the falcon application configuration paths, with wildcards expanded.
+			def resolved_configuration_paths
+				configuration_paths.flat_map do |path|
+					Dir.glob(path)
+				end.uniq
+			end
+			
+			def configuration
+				::Async::Service::Configuration.load(resolved_configuration_paths)
+			end
+		end
+	end
+end

--- a/lib/falcon/environment/virtual.rb
+++ b/lib/falcon/environment/virtual.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
+require_relative 'configured'
+
+require_relative '../service/virtual'
+
+module Falcon
+	module Environment
+		module Virtual
+			include Configured
+			
+			# The service class to use for the virtual host.
+			# @returns [Class]
+			def service_class
+				Service::Virtual
+			end
+			
+			def name
+				service_class.name
+			end
+			
+			# The URI to bind the `HTTPS` -> `falcon host` proxy.
+			def bind_secure
+				"https://[::]:443"
+			end
+			
+			# The URI to bind the `HTTP` -> `HTTPS` redirector.
+			def bind_insecure
+				"http://[::]:80"
+			end
+			
+			# The connection timeout to use for incoming connections.
+			def timeout
+				10.0
+			end
+			
+			# The path to the falcon executable from this gem.
+			# @returns [String]
+			def falcon_path
+				File.expand_path("../../../bin/falcon", __dir__)
+			end
+			
+			# # The insecure endpoint for connecting to the {Redirect} instance.
+			# def insecure_endpoint(**options)
+			# 	Async::HTTP::Endpoint.parse(bind_insecure, **options)
+			# end
+			
+			# # The secure endpoint for connecting to the {Proxy} instance.
+			# def secure_endpoint(**options)
+			# 	Async::HTTP::Endpoint.parse(bind_secure, **options)
+			# end
+			
+			# # An endpoint suitable for connecting to the specified hostname.
+			# def host_endpoint(hostname, **options)
+			# 	endpoint = secure_endpoint(**options)
+				
+			# 	url = URI.parse(bind_secure)
+			# 	url.hostname = hostname
+				
+			# 	return Async::HTTP::Endpoint.new(url, hostname: endpoint.hostname)
+			# end
+		end
+	end
+end


### PR DESCRIPTION
Falcon virtual is currently broken as it isn't expanding globs. This was previously done at the command level, but should be done at the environment/service level, which this PR moves us towards. The same should be done for the redirect and proxy environments.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
