### PR TITLE
WIP: Emit certificate path on start up and update guide

### DIFF
--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -69,14 +69,14 @@ This will run a single-threaded instance of Falcon using `http/1`. While it work
 In order to use `curl` with self-signed localhost certificates, you need to specify `--insecure` or the path of the certificate to validate the request:
 
 ~~~
-> curl -v https://localhost:9292 --cacert ~/.localhost/localhost.crt
+> curl -v https://localhost:9292 --cacert ~/.local/state/localhost.rb/localhost.crt
 *   Trying ::1...
 * TCP_NODELAY set
 * Connected to localhost (::1) port 9292 (#0)
 * ALPN, offering http/1.1
 * Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
 * successfully set certificate verify locations:
-*   CAfile: /Users/samuel/.localhost/localhost.crt
+*   CAfile: /Users/samuel/.local/state/localhost.rb/localhost.crt
   CApath: none
 * TLSv1.2 (OUT), TLS header, Certificate Status (22):
 * TLSv1.2 (OUT), TLS handshake, Client hello (1):

--- a/lib/falcon/endpoint.rb
+++ b/lib/falcon/endpoint.rb
@@ -17,7 +17,7 @@ module Falcon
 		
 		# Build an appropriate SSL context for the given hostname.
 		#
-		# Uses {Localhost::Authority} to generate self-signed certficates.
+		# Uses {Localhost::Authority} to generate self-signed certificates.
 		#
 		# @returns [OpenSSL::SSL::SSLContext]
 		def build_ssl_context(hostname = self.hostname)

--- a/lib/falcon/environment/application.rb
+++ b/lib/falcon/environment/application.rb
@@ -27,7 +27,7 @@ module Falcon
 			
 			# The protocol to use to communicate with the application.
 			#
-			# Typically one of {Async::HTTP::Protocol::HTTP1} or {Async::HTTP::Protocl::HTTP2}.
+			# Typically one of {Async::HTTP::Protocol::HTTP1} or {Async::HTTP::Protocol::HTTP2}.
 			#
 			# @returns [Async::HTTP::Protocol]
 			def protocol

--- a/lib/falcon/service/server.rb
+++ b/lib/falcon/service/server.rb
@@ -43,7 +43,10 @@ module Falcon
 				
 				preload!
 				
-				Console.logger.info(self) {"Starting #{self.name} on #{@endpoint}"}
+				Console.logger.info(self) do
+					"Starting #{self.name} on #{@endpoint}"
+					"- Using certificate: #{Localhost::Authority.path}" if @endpoint.secure?
+				end
 				
 				super
 			end

--- a/lib/falcon/tls.rb
+++ b/lib/falcon/tls.rb
@@ -7,7 +7,7 @@ module Falcon
 	module TLS
 		# The list of supported ciphers.
 		#
-		# We follow "Intermediate compatibility" as oulined here:
+		# We follow "Intermediate compatibility" as outlined here:
 		# <https://wiki.mozilla.org/Security/Server_Side_TLS>
 		SERVER_CIPHERS = [
 			# TLS 1.3:


### PR DESCRIPTION
It is helpful to know the certificate location, for use with curl or other clients.  Also, correct the example in the documentation, so that it is not misleading.

## Types of Changes

- Maintenance.

## Contribution

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
