### PR TITLE
Document binding to HTTP in development

### DIFF
--- a/guides/rails-integration/readme.md
+++ b/guides/rails-integration/readme.md
@@ -11,6 +11,12 @@ Because Rails apps are built on top of Rack, they are compatible with Falcon.
 
 We do not recommend using Rails older than v7.1 with Falcon. If you are using an older version of Rails, you should upgrade to the latest version before using Falcon.
 
+Falcon assumes HTTPS by default (so that browsers can use HTTP2). To run under HTTP in development you can bind it to an explicit scheme, host and port:
+
+```
+falcon serve -b http://localhost:3000
+```
+
 ### Production
 
 The `falcon serve` command is only intended to be used for local development. Follow these steps to run a production Rails app with Falcon:


### PR DESCRIPTION
Document using the `-b` (bind) option of `falcon serve` to bind to an HTTP host in development.

I was hitting [this](https://github.com/socketry/falcon/issues/67) issue when following the Rails integration guide and I couldn't find an obvious reason/solution in the docs. If there's a closed issue with the fix, it might as well be in documentation? Seems like this will be a common stumbling block when trying Falcon in development.

## Types of Changes

Add a note to the Rails integration guide on how to use `falcon serve -b http://...` in development.
