### PR TITLE
Improve compatibility of rackup handler, w.r.t sinatra.

### DIFF
--- a/examples/proxy/application.rb
+++ b/examples/proxy/application.rb
@@ -4,7 +4,7 @@
 # Released under the MIT License.
 # Copyright, 2024, by Samuel Williams.
 
-require 'async/http/client'
+require "async/http/client"
 
 class Application
 	# The endpoint we will proxy requests to:

--- a/examples/sinatra/Gemfile
+++ b/examples/sinatra/Gemfile
@@ -4,4 +4,11 @@
 source "https://rubygems.org"
 
 gem "sinatra"
-gem "falcon"
+gem "falcon", path: "../.."
+
+# Rack dependency:
+
+gem "rack", "~> 2.0"
+# or:
+# gem "rack", "~> 3.0"
+# gem "rackup"

--- a/examples/sinatra/Gemfile.lock
+++ b/examples/sinatra/Gemfile.lock
@@ -1,0 +1,104 @@
+PATH
+  remote: ../..
+  specs:
+    falcon (0.48.3)
+      async
+      async-container (~> 0.18)
+      async-http (~> 0.75)
+      async-http-cache (~> 0.4)
+      async-service (~> 0.10)
+      bundler
+      localhost (~> 1.1)
+      openssl (~> 3.0)
+      process-metrics (~> 0.2)
+      protocol-http (~> 0.31)
+      protocol-rack (~> 0.7)
+      samovar (~> 2.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    async (2.21.1)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.6, >= 1.6.5)
+    async-container (0.18.3)
+      async (~> 2.10)
+    async-http (0.86.0)
+      async (>= 2.10.2)
+      async-pool (~> 0.9)
+      io-endpoint (~> 0.14)
+      io-stream (~> 0.6)
+      metrics (~> 0.12)
+      protocol-http (~> 0.43)
+      protocol-http1 (>= 0.28.1)
+      protocol-http2 (~> 0.22)
+      traces (~> 0.10)
+    async-http-cache (0.4.4)
+      async-http (~> 0.56)
+    async-pool (0.10.2)
+      async (>= 1.25)
+      traces
+    async-service (0.12.0)
+      async
+      async-container (~> 0.16)
+    base64 (0.2.0)
+    console (1.29.2)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.0)
+    io-endpoint (0.14.0)
+    io-event (1.7.5)
+    io-stream (0.6.1)
+    json (2.9.1)
+    localhost (1.3.1)
+    mapping (1.1.1)
+    metrics (0.12.1)
+    mustermann (3.0.3)
+      ruby2_keywords (~> 0.0.1)
+    openssl (3.3.0)
+    process-metrics (0.3.0)
+      console (~> 1.8)
+      json (~> 2)
+      samovar (~> 2.1)
+    protocol-hpack (1.5.1)
+    protocol-http (0.47.1)
+    protocol-http1 (0.28.1)
+      protocol-http (~> 0.22)
+    protocol-http2 (0.22.0)
+      protocol-hpack (~> 1.4)
+      protocol-http (~> 0.18)
+    protocol-rack (0.11.1)
+      protocol-http (~> 0.43)
+      rack (>= 1.0)
+    rack (2.2.10)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
+      rack (~> 2.2, >= 2.2.4)
+    ruby2_keywords (0.0.5)
+    samovar (2.3.0)
+      console (~> 1.0)
+      mapping (~> 1.0)
+    sinatra (3.2.0)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.2.0)
+      tilt (~> 2.0)
+    tilt (2.5.0)
+    traces (0.14.1)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  falcon!
+  rack (~> 2.0)
+  sinatra
+
+BUNDLED WITH
+   2.5.22

--- a/examples/sinatra/app.rb
+++ b/examples/sinatra/app.rb
@@ -1,16 +1,17 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # To run this example, you need to install the `sinatra` gem:
 # $ bundle install
 # $ bundle exec ./app.rb
 
-require 'sinatra/base'
+require "sinatra/base"
 
 class Server < Sinatra::Application
 	set :server, :falcon
 	
 	# Hello World:
-	get '/' do
+	get "/" do
 		"Hello, World!"
 	end
 end

--- a/examples/sinatra/app.rb
+++ b/examples/sinatra/app.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+# To run this example, you need to install the `sinatra` gem:
+# $ bundle install
+# $ bundle exec ./app.rb
+
+require 'sinatra/base'
+
+class Server < Sinatra::Application
+	set :server, :falcon
+	
+	# Hello World:
+	get '/' do
+		"Hello, World!"
+	end
+end
+
+Server.run!

--- a/examples/sinatra/config.ru
+++ b/examples/sinatra/config.ru
@@ -5,6 +5,7 @@
 
 # Middleware that responds to incoming requests:
 require "sinatra/base"
+
 class MyApp < Sinatra::Base
 	get "/" do
 		response = Faraday.get "http://sushi.com/nigiri/sake.json"

--- a/lib/falcon/rackup/handler.rb
+++ b/lib/falcon/rackup/handler.rb
@@ -3,8 +3,6 @@
 # Released under the MIT License.
 # Copyright, 2024, by Samuel Williams.
 
-require "rackup/handler"
-
 require_relative "../../falcon"
 
 require "kernel/sync"

--- a/lib/rack/handler/falcon.rb
+++ b/lib/rack/handler/falcon.rb
@@ -8,9 +8,15 @@ require "rack/handler"
 
 require_relative "../../falcon/rackup/handler"
 
+# Generally speaking, you should not require this file directly, or assume the existance of the `Rack::Handler::Falcon` constant. Instead, use `Rack::Handler.get(:falcon)` to load and access the handler.
+
 module Rack
 	module Handler
-		Falcon = ::Falcon::Rackup::Handler
-		register :falcon, Falcon
+		# Rack (v2) expects the constant to be in the `Rack::Handler` namespace, so we define a new handler class in the `Rack::Handler` namespace that inherits from `Falcon::Rackup::Handler`.
+		class Falcon < ::Falcon::Rackup::Handler
+		end
+		
+		# Rack (v2) expects a string for the handler constant name. `Falcon.to_s` returns a more human friendly name, so we explicitly pass `Falcon.name` to `register` to ensure Rack can find the handler using the registered name.
+		register :falcon, Falcon.name
 	end
 end

--- a/lib/rackup/handler/falcon.rb
+++ b/lib/rackup/handler/falcon.rb
@@ -7,9 +7,15 @@ require "rackup/handler"
 
 require_relative "../../falcon/rackup/handler"
 
+# Generally speaking, you should not require this file directly, or assume the existance of the `Rackup::Handler::Falcon` constant. Instead, use `Rackup::Handler.get(:falcon)` to load and access the handler.
+
 module Rackup
 	module Handler
-		Falcon = ::Falcon::Rackup::Handler
+		# Sinatra (and possibly others) try to extract the name using the final part of the class path, so we define a new class in the `Rack::Handler` namespace that inherits from `Falcon::Rackup::Handler`, that follows that convention.
+		class Falcon < ::Falcon::Rackup::Handler
+		end
+		
+		# Rack (v3) expects a class for the handler constant, so we explicitly pass `Falcon` to `register` to ensure Rack can find the handler using the registered name.
 		register :falcon, Falcon
 	end
 end

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Improve compatibility of rackup handler w.r.t. sinatra.
+
 ## v0.47.8
 
   - Fix Falcon Supervisor implementation: due to invalid code, it was unable to start.


### PR DESCRIPTION
There are some minor compatibility issues with Rack 2's rackup implementation. I also made some minor improvements to both handler implementations (e.g. Sinatra computes `handler_name` from the last component of the registered class path).

Fixes <https://github.com/socketry/falcon/issues/263>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
