### PR TITLE
Fix rubocop issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,9 @@ Layout/IndentationConsistency:
 Layout/BlockAlignment:
   Enabled: true
 
+Layout/EmptyLineAfterMagicComment:
+  Enabled: true
+
 Layout/EndAlignment:
   Enabled: true
   EnforcedStyleAlignWith: start_of_line

--- a/examples/streaming/config.ru
+++ b/examples/streaming/config.ru
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "xrb/template"
 TEMPLATE = XRB::Template.load(<<~'HTML')
 <!DOCTYPE html><html><head><title>99 bottles of beer</title></head><body>

--- a/examples/supervisor/bake.rb
+++ b/examples/supervisor/bake.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 def leak(size: 1024*1024)
 	require "async/http/internet/instance"
 	

--- a/examples/supervisor/bake.rb
+++ b/examples/supervisor/bake.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 def leak(size: 1024*1024)
 	require "async/http/internet/instance"
 	

--- a/examples/unicorn/gems.rb
+++ b/examples/unicorn/gems.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source "https://rubygems.org"
 
 gem "unicorn", "~> 6.1"

--- a/examples/unicorn/gems.rb
+++ b/examples/unicorn/gems.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "unicorn", "~> 6.1"


### PR DESCRIPTION
Fixed the two Rubocop issues. The alternative was to exclude the `examples/` folder, but it seemed appropriate to enforce consistency on `*.rb` files across examples. Added `Layout/EmptyLineAfterMagicComment` so that the autocorrect adds an empty line underneath as well (kept that in a separate commit in case you don't want it). 

## Types of Changes
- Maintenance.

## Contribution
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
