### PR TITLE
Consistent guide examples for using preload

### DIFF
--- a/guides/deployment/readme.md
+++ b/guides/deployment/readme.md
@@ -59,7 +59,9 @@ service hostname do
 	include Falcon::Environment::LetsEncryptTLS
 
 	endpoint do
-		Async::HTTP::Endpoint.parse('http://localhost:3000').with(protocol: Async::HTTP::Protocol::HTTP2)
+		Async::HTTP::Endpoint
+			.parse('http://localhost:3000')
+			.with(protocol: Async::HTTP::Protocol::HTTP2)
 	end
 end
 
@@ -142,10 +144,8 @@ require "falcon/environment/rack"
 require "falcon/environment/supervisor"
 
 service "hello.localhost" do
-
   include Falcon::Environment::SelfSignedTLS
   include Falcon::Environment::Rack
-
 end
 
 service "supervisor" do

--- a/guides/deployment/readme.md
+++ b/guides/deployment/readme.md
@@ -19,7 +19,7 @@ Falcon can be deployed into production either as a standalone application server
 Here is a basic example which hosts a rack application using :
 
 ~~~ ruby
-#!/usr/bin/env falcon-host
+#!/usr/bin/env falcon host
 # frozen_string_literal: true
 
 require "falcon/environment/rack"
@@ -47,7 +47,7 @@ These configuration blocks are evaluated using [async-service](https://github.co
 The environment configuration is defined in the `Falcon::Environment` module. The {ruby Falcon::Environment::Application} environment supports the generic virtual host functionality, but you can customise any parts of the configuration, e.g. to bind a production host to `localhost:3000` using plaintext HTTP/2:
 
 ~~~ ruby
-#!/usr/bin/env falcon-host
+#!/usr/bin/env falcon host
 # frozen_string_literal: true
 
 require "falcon/environment/rack"
@@ -84,6 +84,7 @@ web: bundle exec falcon host
 # falcon.rb
 
 #!/usr/bin/env -S falcon host
+# frozen_string_literal: true
 
 require "falcon/environment/rack"
 
@@ -105,12 +106,16 @@ service hostname do
 	# Heroku only supports HTTP/1.1 at the time of this writing. Review the following for possible updates in the future:
 	# https://devcenter.heroku.com/articles/http-routing#http-versions-supported
 	# https://github.com/heroku/roadmap/issues/34
-	endpoint Async::HTTP::Endpoint.parse("http://0.0.0.0:#{port}").with(protocol: Async::HTTP::Protocol::HTTP11)
+	endpoint Async::HTTP::Endpoint
+		.parse("http://0.0.0.0:#{port}")
+		.with(protocol: Async::HTTP::Protocol::HTTP11)
 end
 ~~~
 
 ~~~ ruby
 # preload.rb
+
+# frozen_string_literal: true
 
 require_relative "config/environment"
 ~~~
@@ -129,7 +134,8 @@ You need to create a `falcon.rb` configuration in the root of your applications,
 
 ~~~ bash
 cat /srv/http/example.com/falcon.rb
-#!/usr/bin/env falcon-host
+#!/usr/bin/env falcon host
+# frozen_string_literal: true
 
 require "falcon/environment/self_signed_tls"
 require "falcon/environment/rack"

--- a/guides/rails-integration/readme.md
+++ b/guides/rails-integration/readme.md
@@ -6,16 +6,16 @@ This guide explains how to host Rails applications with Falcon.
 
 Because Rails apps are built on top of Rack, they are compatible with Falcon.
 
-1. Add `gem 'falcon'` to your `Gemfile` and perhaps remove `gem 'puma'` once you are satisfied with the change.
+1. Add `gem "falcon"` to your `Gemfile` and perhaps remove `gem "puma"` once you are satisfied with the change.
 2. Run `falcon serve` to start a local development server.
 
 We do not recommend using Rails older than v7.1 with Falcon. If you are using an older version of Rails, you should upgrade to the latest version before using Falcon.
 
 Falcon assumes HTTPS by default (so that browsers can use HTTP2). To run under HTTP in development you can bind it to an explicit scheme, host and port:
 
-```
+~~~ bash
 falcon serve -b http://localhost:3000
-```
+~~~
 
 ### Production
 
@@ -23,7 +23,7 @@ The `falcon serve` command is only intended to be used for local development. Fo
 
 1. Create a `falcon.rb` file
 
-```rb
+~~~ rb
 #!/usr/bin/env -S falcon host
 # frozen_string_literal: true
 
@@ -32,17 +32,21 @@ require "falcon/environment/rack"
 hostname = File.basename(__dir__)
 port = ENV["PORT"] || 3000
 
+preload "preload.rb"
+
 service hostname do
 	include Falcon::Environment::Rack
 	endpoint Async::HTTP::Endpoint.parse("http://0.0.0.0:#{port}")
 end
-```
+~~~
 
 2. Create a `preload.rb` file
 
-```rb
+~~~ rb
+# frozen_string_literal: true
+
 require_relative "config/environment"
-```
+~~~
 
 3. Run the production server with `bundle exec falcon host`
 

--- a/guides/rails-integration/readme.md
+++ b/guides/rails-integration/readme.md
@@ -36,6 +36,7 @@ preload "preload.rb"
 
 service hostname do
 	include Falcon::Environment::Rack
+
 	endpoint Async::HTTP::Endpoint.parse("http://0.0.0.0:#{port}")
 end
 ~~~


### PR DESCRIPTION
The Rails Integration guide mentions making a `preload.rb`, but did not show how to use it from `falcon.rb`. I assumed it would automatically look for it but it seems it does not ([link](https://github.com/socketry/falcon/blob/b774a2d5bf4481209ddb9b25b62cdf4154f93d16/lib/falcon/environment/server.rb#L86-L88)). AFAICT, the only preloading done automatically is for the `group :preload` [here](https://github.com/socketry/async-service/blob/2bb2945e44f326066c268b579666642bdf02173d/lib/async/service/controller.rb#L14). In the Heroku example in the Deployment guide I realized that you need to have `preload "preload.rb"` in `falcon.rb`. 

Assuming this, I updated the docs to say this.

I made some consistency and formatting updates in the docs. If you agree with them I can make the same changes across the other guides. If not, I can remove them. 

## Types of Changes
- Maintenance.

## Contribution
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
