### PR TITLE
Add explicit eager_load! to rails preload.rb example

### DIFF
--- a/guides/rails-integration/readme.md
+++ b/guides/rails-integration/readme.md
@@ -47,6 +47,7 @@ end
 # frozen_string_literal: true
 
 require_relative "config/environment"
+Rails.application.eager_load!
 ~~~
 
 3. Run the production server with `bundle exec falcon host`


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

## Types of Changes
Adds an `Rails.application.eager_load!` to the Rails preload.rb example.

<!-- Delete any which don't apply (feel free to modify): -->

- Performance improvement.

I was seeing wild memory consumption in a rails v7.2 app running on heroku with `WEB_CONCURRENCY=3` running Performance-M dynos. Memory usage would steadily increase, often rapidly after boot. I added this change the the preload.rb file and am now seeing much more consistent memory usage and growth. This was the only change introduced during the time below.

![image](https://github.com/user-attachments/assets/b2240b39-106f-417c-8c4b-9f36a856bc6d)

I was surprised this worked! I expected `require "config/environment"` to be sufficient, especially since my production environment has:

```ruby
  # Eager load code on boot. This eager loads most of Rails and
  # your application in memory, allowing both threaded web servers
  # and those relying on copy on write to perform better.
  # Rake tasks automatically ignore this option for performance.
  config.eager_load = true
```

Given `config/environment` calls `Rails.application.initialize!` I would have expected eager loading to happen then. I did find this [example](https://github.com/rails/rails/blob/0367cbf265ff25546230d2f668aa887e09995509/guides/source/action_cable_overview.md?plain=1#L899) in the rails source which calls `eager_load!` after requiring `config/environment`.

I've only let this cook 12 hours, but my traffic and usages are pretty consistent with this app so I feel confident with *my* outcome thus far. I wonder if this change may be circumstantial and not needed with most apps, but thought a PR would be a good place to discuss.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
