### PR TITLE
Move `async-service-supervisor` to gemspec

### DIFF
--- a/falcon.gemspec
+++ b/falcon.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "async-http", "~> 0.75"
 	spec.add_dependency "async-http-cache", "~> 0.4"
 	spec.add_dependency "async-service", "~> 0.19"
+	spec.add_dependency "async-service-supervisor", "~> 0.13"
 	spec.add_dependency "async-utilization", "~> 0.3"
 	spec.add_dependency "bundler"
 	spec.add_dependency "localhost", "~> 1.1"

--- a/gems.rb
+++ b/gems.rb
@@ -25,7 +25,7 @@ gemspec
 
 # gem "fiber-profiler"
 
-gem "async-service-supervisor"
+# gem "async-service-supervisor"
 
 group :maintenance, optional: true do
 	gem "bake-modernize"


### PR DESCRIPTION
Declaring `async-service-supervisor` doesn't work for some reason. I get a `LoadError` when running `bundle exec falcon serve`.

```
cannot load such file -- async/service/supervisor/supervised (LoadError)
```

I've moved the declaration to the gemspec.

Please see the attached `zip` for a demo. Run `bundle exec falcon serve` to see the error. Then amend the `Gemfile` to point to this branch by removing the commented bit. `bundle` and run again and the server starts up correctly.

[falcon-serve-demo.zip](https://github.com/user-attachments/files/25913070/falcon-serve-demo.zip)


## Types of Changes

- Bug fix.

## Contribution

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
