### PR TITLE
Strip `proxy-authorization` header by default.

### DIFF
--- a/lib/falcon/middleware/proxy.rb
+++ b/lib/falcon/middleware/proxy.rb
@@ -43,6 +43,7 @@ module Falcon
 				"keep-alive",
 				"public",
 				"proxy-authenticate",
+				"proxy-authorization",
 				"transfer-encoding",
 				"upgrade",
 			]

--- a/test/falcon/middleware/proxy.rb
+++ b/test/falcon/middleware/proxy.rb
@@ -33,7 +33,7 @@ describe Falcon::Middleware::Proxy do
 		]
 		proxy.prepare_headers(headers)
 		expect(headers["authorization"]).to be == "Bearer application"
-		expect(headers["proxy-authorization"]).to be == nil
+		expect(headers["proxy-authorization"]).to be_nil
 	end
 	
 	it "can select client based on authority" do

--- a/test/falcon/middleware/proxy.rb
+++ b/test/falcon/middleware/proxy.rb
@@ -26,6 +26,16 @@ describe Falcon::Middleware::Proxy do
 	
 	let(:headers) {Protocol::HTTP::Headers["accept" => "*/*"]}
 	
+	it "removes proxy authorization by default" do
+		headers = Protocol::HTTP::Headers[
+			"authorization" => "Bearer application",
+			"proxy-authorization" => "Basic proxy",
+		]
+		proxy.prepare_headers(headers)
+		expect(headers["authorization"]).to be == "Bearer application"
+		expect(headers["proxy-authorization"]).to be == nil
+	end
+	
 	it "can select client based on authority" do
 		request = Protocol::HTTP::Request.new("https", "www.google.com", "GET", "/", nil, headers, nil)
 		


### PR DESCRIPTION
## Summary

Strip `Proxy-Authorization` in the proxy middleware before forwarding requests upstream.

Forwarding the `Proxy-Authorization` it through Falcon's reverse proxy can expose proxy credentials to upstream applications that did not request them. It should also be stripped under [RFC 7235 S4.4](https://www.rfc-editor.org/rfc/rfc7235#section-4.4)