### PR TITLE
fix(server): silence EPIPE/ECONNRESET in accept loop

### DIFF
--- a/lib/falcon/server.rb
+++ b/lib/falcon/server.rb
@@ -59,6 +59,8 @@ module Falcon
 			@connections_total_metric.increment
 			@connections_active_metric.track do
 				super
+			rescue Errno::EPIPE, Errno::ECONNRESET
+				# Client disconnected mid-response — expected, nothing to do.
 			end
 		end
 		


### PR DESCRIPTION
Resolves #333 — silences expected client-disconnect errors that otherwise flood logs with false alarms.

## Problem

When a client disconnects mid-response (e.g. browser navigation, WebSocket teardown, ALB health-check timeout), the Async task runner logs:

```
Task may have ended with unhandled exception.
Errno::ECONNRESET: Connection reset by peer
```

This is particularly noisy with Hotwire/Turbo Drive, where every client-side navigation aborts the previous response.

## Fix

Rescues Errno::EPIPE and Errno::ECONNRESET inside the track{} block in Falcon::Server#accept. These are not actionable errors — the client is simply gone. All other exceptions continue to bubble up normally.

## Testing

The fix can be verified by rapidly navigating between pages in a Falcon-based app with Hotwire/Turbo Drive enabled — the console should no longer show the unhandled-exception warnings for normal client disconnects.