### PR TITLE
Move trace providers out of middleware

### DIFF
--- a/lib/falcon/middleware/proxy.rb
+++ b/lib/falcon/middleware/proxy.rb
@@ -9,7 +9,6 @@ require "protocol/http/headers"
 require "protocol/http/middleware"
 
 require "console/event/failure"
-require "traces/provider"
 
 module Falcon
 	# @namespace
@@ -155,20 +154,6 @@ module Falcon
 				return Protocol::HTTP::Response[502, {"content-type" => "text/plain"}, [error.class.name]]
 			end
 			
-			Traces::Provider(self) do
-				def call(request)
-					attributes = {
-						"authority" => request.authority,
-						"method" => request.method,
-						"path" => request.path,
-						"version" => request.version,
-					}
-					
-					Traces.trace("falcon.middleware.proxy.call", attributes: attributes) do
-						super
-					end
-				end
-			end
 		end
 	end
 end

--- a/lib/falcon/middleware/redirect.rb
+++ b/lib/falcon/middleware/redirect.rb
@@ -62,13 +62,6 @@ module Falcon
 				end
 			end
 			
-			Traces::Provider(self) do
-				def call(request)
-					Traces.trace("falcon.middleware.redirect.call", attributes: {authority: request.authority}) do
-						super
-					end
-				end
-			end
 		end
 	end
 end

--- a/lib/traces/provider/falcon/middleware.rb
+++ b/lib/traces/provider/falcon/middleware.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require_relative "middleware/proxy"
+require_relative "middleware/redirect"

--- a/lib/traces/provider/falcon/middleware/proxy.rb
+++ b/lib/traces/provider/falcon/middleware/proxy.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require_relative "../../../../falcon/middleware/proxy"
+
+require "traces/provider"
+
+Traces::Provider(Falcon::Middleware::Proxy) do
+	def call(request)
+		attributes = {
+			"authority" => request.authority,
+			"method" => request.method,
+			"path" => request.path,
+			"version" => request.version,
+		}
+		
+		Traces.trace("falcon.middleware.proxy.call", attributes: attributes) do
+			super
+		end
+	end
+end

--- a/lib/traces/provider/falcon/middleware/redirect.rb
+++ b/lib/traces/provider/falcon/middleware/redirect.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require_relative "../../../../falcon/middleware/redirect"
+
+require "traces/provider"
+
+Traces::Provider(Falcon::Middleware::Redirect) do
+	def call(request)
+		Traces.trace("falcon.middleware.redirect.call", attributes: {authority: request.authority}) do
+			super
+		end
+	end
+end

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Move Falcon middleware trace providers to `traces/provider/falcon/middleware`.
+
 ## v0.55.5
 
   - Strip `proxy-authorization` header in `Falcon::Middleware::Proxy`.

--- a/test/traces/provider/falcon/middleware.rb
+++ b/test/traces/provider/falcon/middleware.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "traces/provider/falcon/middleware"
+
+require "async/http/endpoint"
+
+describe "traces/provider/falcon/middleware" do
+	let(:headers) {Protocol::HTTP::Headers["accept" => "*/*"]}
+	
+	def reset_trace_context!
+		Traces.trace_context = nil
+	end
+	
+	def expect_trace(name, expected_attributes)
+		mock(Traces) do |mock|
+			mock.wrap(:trace) do |original, actual_name, attributes: nil, &block|
+				expect(actual_name).to be == name
+				expect(attributes).to be == expected_attributes
+				expect(block).not.to be == nil
+				
+				original.call(actual_name, attributes: attributes, &block)
+			end
+		end
+	end
+	
+	it "provides traces for proxy middleware calls" do
+		proxy = Falcon::Middleware::Proxy.new(Falcon::Middleware::BadRequest, {})
+		request = Protocol::HTTP::Request.new("https", "www.example.com", "GET", "/", "HTTP/1.1", headers, nil)
+		
+		reset_trace_context!
+		expect_trace("falcon.middleware.proxy.call", {
+			"authority" => "www.example.com",
+			"method" => "GET",
+			"path" => "/",
+			"version" => "HTTP/1.1",
+		})
+		
+		response = proxy.call(request)
+		
+		expect(response.status).to be == 400
+		expect(Traces.trace_context).to be_a(Traces::Context)
+	end
+	
+	it "provides traces for redirect middleware calls" do
+		redirect = Falcon::Middleware::Redirect.new(
+			Falcon::Middleware::NotFound,
+			{},
+			Async::HTTP::Endpoint.parse("https://localhost"),
+		)
+		
+		request = Protocol::HTTP::Request.new("http", "www.example.com", "GET", "/", "HTTP/1.1", headers, nil)
+		
+		reset_trace_context!
+		expect_trace("falcon.middleware.redirect.call", {authority: "www.example.com"})
+		
+		response = redirect.call(request)
+		
+		expect(response.status).to be == 404
+		expect(Traces.trace_context).to be_a(Traces::Context)
+	end
+end


### PR DESCRIPTION
## Summary

- Move Falcon middleware trace providers into `lib/traces/provider/falcon/middleware/*`.
- Add an aggregate `traces/provider/falcon/middleware` provider entrypoint.
- Test provider loading with `TRACES_BACKEND=traces/backend/test`.

## Testing

- `ruby -c lib/traces/provider/falcon/middleware.rb && ruby -c lib/traces/provider/falcon/middleware/proxy.rb && ruby -c lib/traces/provider/falcon/middleware/redirect.rb && ruby -c test/traces/provider/falcon/middleware.rb`
- `bundle exec sus test/traces/provider/falcon/middleware.rb test/falcon/middleware/proxy.rb`
- `bundle exec bake traces:provider:list`