### PR TITLE
Minor fixes to let's encrypt environment

### DIFF
--- a/lib/falcon/environment/lets_encrypt_tls.rb
+++ b/lib/falcon/environment/lets_encrypt_tls.rb
@@ -11,7 +11,7 @@ module Falcon
 		# Provides an environment that uses "Lets Encrypt" for TLS.
 		module LetsEncryptTLS
 			include TLS
-
+			
 			# The Lets Encrypt certificate store path.
 			# @parameter [String]
 			def lets_encrypt_root

--- a/lib/falcon/environment/lets_encrypt_tls.rb
+++ b/lib/falcon/environment/lets_encrypt_tls.rb
@@ -10,6 +10,8 @@ module Falcon
 	module Environment
 		# Provides an environment that uses "Lets Encrypt" for TLS.
 		module LetsEncryptTLS
+			include TLS
+
 			# The Lets Encrypt certificate store path.
 			# @parameter [String]
 			def lets_encrypt_root

--- a/lib/falcon/environment/tls.rb
+++ b/lib/falcon/environment/tls.rb
@@ -55,7 +55,7 @@ module Falcon
 			# The private key.
 			# @returns [OpenSSL::PKey::RSA]
 			def ssl_private_key
-				OpenSSL::PKey::RSA.new(File.read(ssl_private_key_path))
+				OpenSSL::PKey.read(File.read(ssl_private_key_path))
 			end
 			
 			# The SSL context to use for incoming connections.


### PR DESCRIPTION
I ran into a couple of issues trying to deploy a Rack app using Falcon Virtual secured with a Let's Encrypt certificate.

1) The `Falcon::Environment::TLS` module needs to be separately included in addition to `Falcon::Environment::LetsEncryptTLS`. 

```ruby
service "service.example" do
  include Falcon::Environment::Rack
  include Falcon::Environment::TLS
  include Falcon::Environment::LetsEncryptTLS
end
```

I think this is a bit fiddly, and the docs don't mention this additional `include` anywhere. I've included the `TLS` module in the `LetsEncryptTLS` module so just a single include in the configuration is enough.

2) I got the following error after issuing the certificate:

`OpenSSL::PKey::PKeyError: incorrect pkey type: id-ecPublicKey`

I fixed this by adding the below line to my config:

`ssl_private_key { OpenSSL::PKey.read(File.read(ssl_private_key_path)) }`

This PR changes the `TLS` environment to use `OpenSSL::PKey.read` to fix this issue.

## Types of Changes

- Bug fix.

## Contribution

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
