### PR TITLE
Run container tests in scheduler context

### DIFF
--- a/test/falcon/command/serve.rb
+++ b/test/falcon/command/serve.rb
@@ -6,8 +6,11 @@
 
 require "falcon/command/serve"
 require "sus/fixtures/console/captured_logger"
+require "sus/fixtures/async/scheduler_context"
 
 ServeCommand = Sus::Shared("falcon serve") do
+	include Sus::Fixtures::Async::SchedulerContext
+	
 	let(:command) do
 		subject[
 			"--port", port,

--- a/test/falcon/service/server.rb
+++ b/test/falcon/service/server.rb
@@ -6,8 +6,11 @@
 require "falcon/service/server"
 require "falcon/environment/server"
 require "falcon/environment/rackup"
+require "sus/fixtures/async/scheduler_context"
 
 describe Falcon::Service::Server do
+	include Sus::Fixtures::Async::SchedulerContext
+	
 	let(:environment) do
 		Async::Service::Environment.new(Falcon::Environment::Server).with(
 			Falcon::Environment::Rackup,


### PR DESCRIPTION
## Summary

- Use Sus::Fixtures::Async::SchedulerContext for Falcon tests that start Async::Container directly.
- Covers serve command integration and server service container startup paths for async-container v0.36.0.

## Testing

- PATH=/Users/samuel/.local/state/tec/toolchain/base_profile/bin:$PATH bundle exec sus --verbose test/falcon/command/serve.rb test/falcon/service/server.rb
- PATH=/Users/samuel/.local/state/tec/toolchain/base_profile/bin:$PATH bundle exec sus --verbose