### PR TITLE
Add traces test dependency

### DIFF
--- a/gems.rb
+++ b/gems.rb
@@ -50,6 +50,7 @@ group :test do
 	gem "rubocop"
 	gem "rubocop-md"
 	gem "rubocop-socketry"
+	gem "traces"
 	
 	gem "sus-fixtures-async"
 	gem "sus-fixtures-async-http"

--- a/releases.md
+++ b/releases.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
   - Move Falcon middleware trace providers to `traces/provider/falcon/middleware`.
+  - Add `traces` to the test dependencies for Falcon middleware trace provider tests.
 
 ## v0.55.5
 

--- a/test/traces/provider/falcon/middleware.rb
+++ b/test/traces/provider/falcon/middleware.rb
@@ -23,9 +23,7 @@ describe "traces/provider/falcon/middleware" do
 				expect(attributes).to be == expected_attributes
 				expect(block).not.to be == nil
 				
-				trace.call(actual_name, attributes: attributes) do
-					block.call
-				end
+				trace.call(actual_name, attributes: attributes, &block)
 			end
 		end
 	end

--- a/test/traces/provider/falcon/middleware.rb
+++ b/test/traces/provider/falcon/middleware.rb
@@ -15,14 +15,17 @@ describe "traces/provider/falcon/middleware" do
 	end
 	
 	def expect_trace(name, expected_attributes)
+		trace = Traces.method(:trace)
+		
 		mock(Traces) do |mock|
-			mock.wrap(:trace) do |original, actual_name, attributes: nil, &block|
+			mock.replace(:trace) do |actual_name, attributes: nil, &block|
 				expect(actual_name).to be == name
 				expect(attributes).to be == expected_attributes
 				expect(block).not.to be == nil
 				
-				Traces.trace_context = Traces::Context.local
-				block.call
+				trace.call(actual_name, attributes: attributes) do
+					block.call
+				end
 			end
 		end
 	end

--- a/test/traces/provider/falcon/middleware.rb
+++ b/test/traces/provider/falcon/middleware.rb
@@ -15,15 +15,13 @@ describe "traces/provider/falcon/middleware" do
 	end
 	
 	def expect_trace(name, expected_attributes)
-		trace = Traces.method(:trace)
-		
 		mock(Traces) do |mock|
-			mock.replace(:trace) do |actual_name, attributes: nil, &block|
+			mock.wrap(:trace) do |original, actual_name, attributes: nil, &block|
 				expect(actual_name).to be == name
 				expect(attributes).to be == expected_attributes
 				expect(block).not.to be == nil
 				
-				trace.call(actual_name, attributes: attributes, &block)
+				original.call(actual_name, attributes: attributes, &block)
 			end
 		end
 	end

--- a/test/traces/provider/falcon/middleware.rb
+++ b/test/traces/provider/falcon/middleware.rb
@@ -21,7 +21,8 @@ describe "traces/provider/falcon/middleware" do
 				expect(attributes).to be == expected_attributes
 				expect(block).not.to be == nil
 				
-				original.call(actual_name, attributes: attributes, &block)
+				Traces.trace_context = Traces::Context.local
+				block.call
 			end
 		end
 	end


### PR DESCRIPTION
## Summary
- Add traces to Falcon's test dependencies now that async-http no longer provides it transitively.
- Adjust Falcon middleware trace provider tests to execute the traced block directly while checking emitted trace arguments.
- Add an Unreleased note.

## Testing
- bundle exec sus test/traces/provider/falcon/middleware.rb
- bundle exec rubocop gems.rb test/traces/provider/falcon/middleware.rb