### PR TITLE
Add load-aware Envoy cluster example

### DIFF
--- a/examples/cluster/Dockerfile
+++ b/examples/cluster/Dockerfile
@@ -5,8 +5,10 @@ WORKDIR /code
 
 ENV BUNDLE_GEMFILE=/code/gems.rb
 
-COPY . .
+COPY gems.rb .
 
 RUN bundle install
+
+COPY . .
 
 CMD ["bundle", "exec", "async-service", "falcon.rb"]

--- a/examples/cluster/compose.yaml
+++ b/examples/cluster/compose.yaml
@@ -9,7 +9,7 @@ services:
       - "10000:10000"
 
   envoy:
-    image: envoyproxy/envoy:v1.32-latest
+    image: envoyproxy/envoy:v1.39-latest
     command: ["envoy", "-c", "/etc/envoy/envoy.yaml", "--log-level", "info"]
     network_mode: "service:falcon"
     volumes:

--- a/examples/cluster/envoy.yaml
+++ b/examples/cluster/envoy.yaml
@@ -9,6 +9,9 @@ dynamic_resources:
     grpc_services:
       - envoy_grpc:
           cluster_name: xds_cluster
+  cds_config:
+    ads: {}
+    resource_api_version: V3
 
 static_resources:
   listeners:
@@ -25,6 +28,7 @@ static_resources:
                 stat_prefix: ingress_http
                 route_config:
                   name: local_route
+                  validate_clusters: false
                   virtual_hosts:
                     - name: falcon
                       domains: ["*"]
@@ -39,16 +43,6 @@ static_resources:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
   clusters:
-    - name: cluster
-      connect_timeout: 1s
-      type: EDS
-      lb_policy: ROUND_ROBIN
-      eds_cluster_config:
-        service_name: cluster
-        eds_config:
-          ads: {}
-          resource_api_version: V3
-
     - name: xds_cluster
       connect_timeout: 1s
       type: STATIC
@@ -59,7 +53,7 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: 127.0.0.1
+                      address: "::1"
                       port_value: 18000
       typed_extension_protocol_options:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/examples/cluster/falcon.rb
+++ b/examples/cluster/falcon.rb
@@ -44,7 +44,8 @@ service "supervisor" do
 	monitors do
 		[
 			Async::Service::Supervisor::Envoy::Monitor.new(
-				bind: "http://127.0.0.1:18000",
+				bind: "http://[::]:18000",
+				orca: true,
 			),
 		]
 	end

--- a/examples/cluster/falcon.rb
+++ b/examples/cluster/falcon.rb
@@ -42,10 +42,14 @@ service "supervisor" do
 	include Async::Service::Supervisor::Environment
 	
 	monitors do
+		utilization_monitor = Async::Service::Supervisor::UtilizationMonitor.new
+		
 		[
+			utilization_monitor,
 			Async::Service::Supervisor::Envoy::Monitor.new(
 				bind: "http://[::]:18000",
 				orca: true,
+				utilization_monitor: utilization_monitor,
 			),
 		]
 	end

--- a/examples/cluster/gems.rb
+++ b/examples/cluster/gems.rb
@@ -6,4 +6,4 @@
 source "https://rubygems.org"
 
 gem "falcon", "~> 0.56.0"
-gem "async-service-supervisor-envoy", "~> 0.2.0"
+gem "async-service-supervisor-envoy", "~> 0.3.0"

--- a/examples/cluster/readme.md
+++ b/examples/cluster/readme.md
@@ -1,6 +1,6 @@
 # Cluster with Envoy
 
-This example runs a two-worker Falcon cluster behind Envoy using Docker Compose. Falcon publishes each worker's dynamically bound endpoint to Envoy through the supervisor's xDS control plane.
+This example runs a two-worker Falcon cluster behind Envoy using Docker Compose. Falcon publishes each worker's dynamically bound endpoint through the supervisor's xDS control plane. The supervisor also reports per-worker CPU utilization and request throughput using ORCA, allowing Envoy to shift traffic toward workers with more available capacity.
 
 See the [Dynamic Clusters with Envoy](../../guides/cluster-deployment/readme.md) guide for the architecture, endpoint registration lifecycle, and deployment considerations.
 

--- a/guides/cluster-deployment/readme.md
+++ b/guides/cluster-deployment/readme.md
@@ -92,10 +92,14 @@ service "supervisor" do
 	include Async::Service::Supervisor::Environment
 	
 	monitors do
+		utilization_monitor = Async::Service::Supervisor::UtilizationMonitor.new
+		
 		[
+			utilization_monitor,
 			Async::Service::Supervisor::Envoy::Monitor.new(
 				bind: "http://[::]:18000",
 				orca: true,
+				utilization_monitor: utilization_monitor,
 			),
 		]
 	end

--- a/guides/cluster-deployment/readme.md
+++ b/guides/cluster-deployment/readme.md
@@ -1,6 +1,6 @@
 # Dynamic Clusters with Envoy
 
-This guide explains how to run Falcon workers with independently bound endpoints and publish them dynamically to Envoy using xDS.
+This guide explains how to run Falcon workers with independently bound endpoints, publish them dynamically using xDS, and balance requests according to their current load using ORCA.
 
 ## When to Use a Cluster
 
@@ -17,7 +17,9 @@ A regular {ruby Falcon::Service::Server} binds one listener and shares it with e
 
 Each cluster worker can bind to `localhost` with port `0`, allowing the operating system to assign an available port. Falcon describes the bound resource with a {ruby Falcon::Listener}, including its name, scheme, supported protocols, and concrete addresses.
 
-The worker registers that listener with `async-service-supervisor-envoy`. The supervisor publishes the current workers through an xDS control plane, and Envoy uses Endpoint Discovery Service (EDS) updates to maintain the upstream cluster.
+The worker registers that listener with `async-service-supervisor-envoy`. The supervisor publishes the current workers and load-balancing policy through an xDS control plane. Envoy uses Cluster Discovery Service (CDS) and Endpoint Discovery Service (EDS) updates to maintain the upstream cluster.
+
+The supervisor also samples each worker's CPU utilization and request counter. It exposes those measurements using out-of-band Open Request Cost Aggregation (ORCA), which lets Envoy's client-side weighted-round-robin policy direct more requests to workers with more available capacity. This avoids coupling connection acceptance to a process-local token limiter while still responding to CPU-heavy work.
 
 Requests arrive at Envoy's stable listener. Envoy selects one of the discovered worker endpoints and forwards the request to it:
 
@@ -29,14 +31,15 @@ flowchart LR
 		Envoy[Envoy]
 
 		subgraph Falcon[Falcon container]
-			Supervisor[Supervisor and xDS control plane]
+			Supervisor[Supervisor, xDS, and ORCA]
 			Worker1[Falcon worker 1]
 			Worker2[Falcon worker 2]
 		end
 
 		Worker1 -.->|Register endpoint| Supervisor
 		Worker2 -.->|Register endpoint| Supervisor
-		Supervisor -.->|EDS over ADS on port 18000| Envoy
+		Supervisor -.->|CDS and EDS over ADS| Envoy
+		Supervisor -.->|Per-worker ORCA reports| Envoy
 		Envoy -->|HTTP on dynamic port| Worker1
 		Envoy -->|HTTP on dynamic port| Worker2
 	end
@@ -48,7 +51,7 @@ Add Falcon and the Envoy supervisor integration to your `gems.rb`:
 
 ```ruby
 gem "falcon", "~> 0.56.0"
-gem "async-service-supervisor-envoy", "~> 0.2"
+gem "async-service-supervisor-envoy", "~> 0.3"
 ```
 
 Define a Falcon cluster service and an accompanying supervisor in `falcon.rb`:
@@ -91,14 +94,15 @@ service "supervisor" do
 	monitors do
 		[
 			Async::Service::Supervisor::Envoy::Monitor.new(
-				bind: "http://127.0.0.1:18000",
+				bind: "http://[::]:18000",
+				orca: true,
 			),
 		]
 	end
 end
 ```
 
-The Falcon service name becomes the listener name, so the corresponding Envoy EDS cluster uses `cluster` as its service name. Configure Envoy to receive aggregated discovery updates from the supervisor:
+The Falcon service name becomes the listener name, so the corresponding Envoy cluster uses `cluster` as its service name. Configure Envoy to receive cluster and endpoint updates from the supervisor:
 
 ```yaml
 node:
@@ -112,6 +116,9 @@ dynamic_resources:
     grpc_services:
       - envoy_grpc:
           cluster_name: xds_cluster
+  cds_config:
+    ads: {}
+    resource_api_version: V3
 
 static_resources:
   listeners:
@@ -128,6 +135,7 @@ static_resources:
                 stat_prefix: ingress_http
                 route_config:
                   name: local_route
+                  validate_clusters: false
                   virtual_hosts:
                     - name: falcon
                       domains: ["*"]
@@ -142,16 +150,6 @@ static_resources:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
   clusters:
-    - name: cluster
-      connect_timeout: 1s
-      type: EDS
-      lb_policy: ROUND_ROBIN
-      eds_cluster_config:
-        service_name: cluster
-        eds_config:
-          ads: {}
-          resource_api_version: V3
-
     - name: xds_cluster
       connect_timeout: 1s
       type: STATIC
@@ -162,7 +160,7 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: 127.0.0.1
+                      address: "::1"
                       port_value: 18000
       typed_extension_protocol_options:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -171,7 +169,7 @@ static_resources:
             http2_protocol_options: {}
 ```
 
-The `xds_cluster` connection uses HTTP/2 because ADS is served over gRPC.
+The `xds_cluster` connection uses HTTP/2 because ADS is served over gRPC. The supervisor serves both ADS and ORCA on port `18000`; Envoy uses that as an alternative to each worker's HTTP port when opening ORCA streams. Envoy 1.39 or later is required for this alternative reporting-port configuration.
 
 ## Worker Registration
 
@@ -179,19 +177,24 @@ When each worker starts:
 
 1. Falcon binds the worker to an available loopback port.
 2. The worker registers its concrete addresses and supported protocols with the supervisor.
-3. The supervisor's Envoy monitor publishes the current worker endpoints as an EDS resource.
-4. Envoy receives the resource over its Aggregated Discovery Service (ADS) connection and updates its upstream cluster.
+3. The supervisor's Envoy monitor publishes the cluster policy and current worker endpoints as CDS and EDS resources.
+4. Envoy receives the resources over its Aggregated Discovery Service (ADS) connection and updates its upstream cluster.
+5. The supervisor samples worker CPU time and request totals, then streams the current load reports to Envoy using ORCA.
+
+The first processor and request samples establish baselines. Load-aware weights become available after the next sampling interval. If a report is temporarily unavailable, Envoy retains its normal policy fallback rather than making the worker unreachable.
 
 The listener preserves all addresses returned by the bound endpoint. This allows the same interface to describe IP sockets, Unix-domain sockets, and endpoints with additional addresses.
 
 ## Worker Restarts
 
-If a worker exits, its supervisor connection closes and the monitor publishes an EDS update without that endpoint. Falcon restarts the worker, which binds a new available port and registers it. The monitor then publishes another update, and Envoy receives both changes over its existing ADS stream without polling or restarting.
+If a worker exits, its supervisor connection closes and the monitor removes both its endpoint and ORCA report. Falcon restarts the worker, which binds a new available port and registers it. The monitor then publishes another update, and Envoy receives both changes over its existing ADS stream without polling or restarting.
 
 This lifecycle is important when ports are ephemeral or a directory may contain stale Unix-domain socket paths: consumers should use the supervisor's current endpoint state as the source of truth.
 
 ## Network Topology
 
-Falcon and Envoy can run in the same network namespace, allowing workers to bind to loopback addresses while remaining reachable by Envoy. With Docker Compose, `network_mode: service:falcon` gives the Envoy service access to Falcon's network namespace, so `127.0.0.1` and `localhost` refer to the same loopback interface for both processes.
+Falcon and Envoy can run in the same network namespace, allowing workers to bind to loopback addresses while remaining reachable by Envoy. With Docker Compose, `network_mode: service:falcon` gives the Envoy service access to Falcon's network namespace, so loopback addresses refer to the same interface for both processes.
+
+The configuration binds the supervisor endpoint to the IPv6 wildcard address because `localhost` worker endpoints use IPv6 in the container. Envoy connects to ADS through `::1`; for each ORCA stream it uses the worker's address with the configured supervisor port `18000`. The supervisor listener must therefore be reachable using the same address family as every published worker endpoint.
 
 Without a shared network namespace, Envoy cannot connect to worker endpoints bound to Falcon's loopback interface. In a different deployment topology, bind workers to an interface that Envoy can reach and apply the appropriate network access controls.


### PR DESCRIPTION
## Summary

- configure the cluster example to discover its Envoy cluster dynamically through CDS and EDS
- enable out-of-band ORCA reports and client-side weighted round-robin balancing
- document load reporting, worker restarts, and the shared network topology
- improve the example image build layering

## Verification

- `bundle exec sus` (110 tests, 476 assertions)
- targeted RuboCop checks
- Envoy configuration validation
- Docker Compose end-to-end requests through Envoy
- verified two active ORCA sessions, received reports, distinct worker weights, and endpoint/report replacement after killing a worker

## Dependencies

Merge and release these first:

- socketry/async-service-supervisor#10
- socketry/async-grpc-xds#3
- socketry/async-service-supervisor-envoy#5
